### PR TITLE
Delete `show(::IO, ::Type)` specialization

### DIFF
--- a/src/viewtypes.jl
+++ b/src/viewtypes.jl
@@ -35,7 +35,6 @@ struct TupleView{T, N, Skip, A} <: AbstractVector{T}
     data::A
     connect::Bool
 end
-Base.show(io::IO, ::Type{<: TupleView{T, N, Skip}}) where {T, N, Skip} = print(io, "TupleView{$T, $Skip}")
 
 function Base.size(x::TupleView{T, N, M}) where {T, N, M}
     nitems = length(x.data) ÷ (N - (N - M))


### PR DESCRIPTION
Overloading `show` for types is strongly discouraged. I'm currently tracking down a Julia segfault that's caused by this line.

Refs:
- https://github.com/JuliaMath/FixedPointNumbers.jl/pull/11
- https://github.com/PainterQubits/Unitful.jl/issues/321