### PR TITLE
Give out points of geometries

### DIFF
--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -56,10 +56,10 @@ function convert_simplex(::Type{Point{N, T}}, x) where {N, T}
     N2 = length(x)
     return (Point{N, T}(ntuple(i-> i <= N2 ? T(x[i]) : T(0), N)),)
 end
-function convert_simplex(::Type{Point{N, T}}, x::Line) where {N, T}
-    N2 = length(x)
-    return (Point{N, T}[x[1], x[2]])
-end
+# function convert_simplex(::Type{Point{N, T}}, x::Line) where {N, T}
+#     N2 = length(x)
+#     return (Point{N, T}[x[1])
+# end
 
 function convert_simplex(::Type{Vec{N, T}}, x) where {N, T}
     N2 = length(x)

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -56,6 +56,10 @@ function convert_simplex(::Type{Point{N, T}}, x) where {N, T}
     N2 = length(x)
     return (Point{N, T}(ntuple(i-> i <= N2 ? T(x[i]) : T(0), N)),)
 end
+function convert_simplex(::Type{Point{N, T}}, x::Line) where {N, T}
+    N2 = length(x)
+    return (Point{N, T}[x[1], x[2]])
+end
 
 function convert_simplex(::Type{Vec{N, T}}, x) where {N, T}
     N2 = length(x)

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -56,10 +56,6 @@ function convert_simplex(::Type{Point{N, T}}, x) where {N, T}
     N2 = length(x)
     return (Point{N, T}(ntuple(i-> i <= N2 ? T(x[i]) : T(0), N)),)
 end
-# function convert_simplex(::Type{Point{N, T}}, x::Line) where {N, T}
-#     N2 = length(x)
-#     return (Point{N, T}[x[1])
-# end
 
 function convert_simplex(::Type{Vec{N, T}}, x) where {N, T}
     N2 = length(x)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -116,10 +116,9 @@ function decompose(::Type{P}, pol::Polygon) where {P<:AbstractPoint}
     if isempty(pol.interiors)
         return decompose(P, pol.exterior)
     else
-        arr = P[]
-        push!(arr, decompose(P, pol.exterior)...)
+        arr = copy(decompose(P, pol.exterior))
         for i in pol.interiors
-            push!(arr, decompose(P, i)...)
+            append!(arr, decompose(P, i))
         end
         return arr
     end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -116,11 +116,15 @@ function decompose(::Type{P}, pol::Polygon) where {P<:AbstractPoint}
     if isempty(pol.interiors)
         return decompose(P, pol.exterior)
     else
-        points = Array{Union{Point, Array}}[]
-        push!(points, decompose(P, pol.exterior), [decompose(P, pol.interiors[1]) for i in pol.interiors])
-        return points
+        arr = P[]
+        push!(arr, decompose(P, pol.exterior)...)
+        for i in pol.interiors
+            push!(arr, decompose(P, i)...)
+        end
+        return arr
     end
 end
+
 decompose(::Type{P}, ls::LineString) where {P<:AbstractPoint} = ls.points.parent.data
 decompose_uv(primitive) = decompose(UV(), primitive)
 decompose_uvw(primitive) = decompose(UVW(), primitive)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -111,11 +111,8 @@ end
 function decompose(::Type{T}, primitive) where {T}
     return collect_with_eltype(T, primitive)
 end
-"""
-decompose a linesting into points
-"""
-decompose(::Type{P}, ls::LineString) where {P<:AbstractPoint} = ls.points.parent.data
 
+decompose(::Type{P}, ls::LineString) where {P<:AbstractPoint} = ls.points.parent.data
 decompose_uv(primitive) = decompose(UV(), primitive)
 decompose_uvw(primitive) = decompose(UVW(), primitive)
 decompose_normals(primitive) = decompose(Normal(), primitive)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -112,6 +112,15 @@ function decompose(::Type{T}, primitive) where {T}
     return collect_with_eltype(T, primitive)
 end
 
+function decompose(::Type{P}, pol::Polygon) where {P<:AbstractPoint}
+    if isempty(pol.interiors)
+        return decompose(P, pol.exterior)
+    else
+        points = Array{Union{Point, Array}}[]
+        push!(points, decompose(P, pol.exterior), [decompose(P, pol.interiors[1]) for i in pol.interiors])
+        return points
+    end
+end
 decompose(::Type{P}, ls::LineString) where {P<:AbstractPoint} = ls.points.parent.data
 decompose_uv(primitive) = decompose(UV(), primitive)
 decompose_uvw(primitive) = decompose(UVW(), primitive)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -111,6 +111,10 @@ end
 function decompose(::Type{T}, primitive) where {T}
     return collect_with_eltype(T, primitive)
 end
+"""
+decompose a linesting into points
+"""
+decompose(::Type{P}, ls::LineString) where {P<:AbstractPoint} = ls.points.parent.data
 
 decompose_uv(primitive) = decompose(UV(), primitive)
 decompose_uvw(primitive) = decompose(UVW(), primitive)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,7 +373,21 @@ end
     @test coordinates(m) === points
 
     linestring = LineString(Point{2, Int}[(10, 10), (20, 20), (10, 40)])
-    @test decompose(Point{2, Int}, linestring) == Point{2, Int64}[[10, 10], [20, 20], [10, 40]]
+    pts = Point{2, Int}[(10, 10), (20, 20), (10, 40)]
+    linestring = LineString(pts)
+    pts_decomp = decompose(Point{2, Int}, linestring)
+    @test pts === pts_decomp
+
+    pts_ext = Point{2, Int}[(5, 1), (3, 3), (4, 8), (1, 2), (5, 1)]
+    ls_ext = LineString(pts_ext)
+    pts_int1 = Point{2, Int}[(2, 2), (3, 8),(5, 6), (3, 4), (2, 2)]
+    ls_int1 = LineString(pts_int1)
+    pts_int2 = Point{2, Int}[(3, 2), (4, 5),(6, 1), (1, 4), (3, 2)]
+    ls_int2 =  LineString(pts_int2)
+    poly_ext = Polygon(ls_ext)
+    poly_ext_int = Polygon(ls_ext, [ls_int1, ls_int2])
+    @test decompose(Point{2, Int}, poly_ext) == pts_ext
+    @test decompose(Point{2, Int}, poly_ext_int) == [pts_ext..., pts_int1..., pts_int2...]
 end
 
 @testset "convert mesh + meta" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -371,6 +371,9 @@ end
     points = decompose(Point2f0, Circle(Point2f0(0), 1))
     m = GeometryBasics.mesh(points)
     @test coordinates(m) === points
+
+    linestring = LineString(Point{2, Int}[(10, 10), (20, 20), (10, 40)])
+    @test decompose(Point{2, Int}, linestring) == Point{2, Int64}[[10, 10], [20, 20], [10, 40]]
 end
 
 @testset "convert mesh + meta" begin


### PR DESCRIPTION
PR for #69  
So this overloads the `convert_simplex()` method to break down a linestring. 
```julia
ls1=LineString([Point(1, 2), Point(4,5), Point(10, 8), Point(1, 2)])
decompose(Point{2, Int}, ls1)
6-element Array{Point{2,Int64},1}:
 [1, 2]
 [4, 5]
 [4, 5]
 [10, 8]
 [10, 8]
 [1, 2]
```
The repetition of Points is the only visible issue currently. Expected is: 
```julia
ls1.points.parent.data
4-element Array{Point{2,Int64},1}:
 [1, 2]
 [4, 5]
 [10, 8]
 [1, 2]
```
