### PR TITLE
Improve layout of docstring

### DIFF
--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -50,11 +50,11 @@ Face(F::Type{NgonFace{N, FT}}, ::Type{T}) where {FT, N, T} = F
 
 """
 Fixed Size Polygon, e.g.
-N 1-2 : Illegal!
-N = 3 : Triangle
-N = 4 : Quadrilateral (or Quad, Or tetragon)
-N = 5 : Pentagon
-...
+- N 1-2 : Illegal!
+- N = 3 : Triangle
+- N = 4 : Quadrilateral (or Quad, Or tetragon)
+- N = 5 : Pentagon
+- ...
 """
 struct Ngon{
         Dim, T <: Real,


### PR DESCRIPTION
Without the dashes, the docstring is printed as a single line, which makes it difficult to read.