### PR TITLE
fix minor convert_simplex method ambiguity

### DIFF
--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -15,6 +15,7 @@ function convert_simplex(NFT::Type{NgonFace{N, T1}}, f::Union{NgonFace{N, T2}}) 
 end
 
 convert_simplex(NFT::Type{NgonFace{3,T}}, f::NgonFace{3,T2}) where {T, T2} = (convert(NFT, f),)
+convert_simplex(NFT::Type{NgonFace{2,T}}, f::NgonFace{2,T2}) where {T, T2} = (convert(NFT, f),)
 
 """
     convert_simplex(::Type{Face{3}}, f::Face{N})

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -138,6 +138,15 @@ NFace = NgonFace
         LineFace{Int}(3,4),
         LineFace{Int}(4,1)
     )
+
+    @testset "NgonFace ambiguity" begin
+        face = NgonFace((1,2))
+        @test convert_simplex(NgonFace{2, UInt32}, face) === (NgonFace{2, UInt32}((1,2)),)
+        @test convert_simplex(typeof(face), face) === (face,)
+        face = NgonFace((1,))
+        @test convert_simplex(NgonFace{1, UInt32}, face) === (NgonFace{1, UInt32}((1,)),)
+        @test convert_simplex(typeof(face), face) === (face,)
+    end
 end
 
 


### PR DESCRIPTION
```julia
using Makie
using GeometryBasics
pts = rand(Point3f0, 10)
edgs  = LineFace{Int}[(1,2), (3,4)]
display(wireframe(connect(pts, edgs)))
```
did not work before this patch.