### PR TITLE
fix precompililation error on julia < v1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ language: julia
 os:
   - linux
 julia:
+  - 1.2
+  - 1.3
+  - 1.4
   - 1
+  - nightly
 if: branch = master OR tag IS present OR type = pull_request
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@
 language: julia
 os:
   - linux
+  - osx
+  - windows
 julia:
-  - 1.2
   - 1.3
   - 1.4
   - 1
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 if: branch = master OR tag IS present OR type = pull_request
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeometryBasics"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 authors = ["SimonDanisch <sdanisch@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 EarCut_jll = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
@@ -16,7 +16,7 @@ IterTools = "1.3.0"
 StaticArrays = "0.12"
 StructArrays = "0.3,0.4"
 Tables = "0.2, 1"
-julia = "1.2"
+julia = "1.3"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -143,7 +143,7 @@ Polygon triangluation!
 function mesh(polygon::AbstractVector{P}; pointtype=P, facetype=GLTriangleFace,
               normaltype=nothing) where {P<:AbstractPoint{2}}
 
-    return mesh(Polygon(polygon); pointtype, facetype, normaltype)
+    return mesh(Polygon(polygon); pointtype=pointtype, facetype=facetype, normaltype=normaltype)
 end
 
 function mesh(polygon::AbstractPolygon{Dim, T}; pointtype=Point{Dim, T}, facetype=GLTriangleFace,


### PR DESCRIPTION
fixes the following error:
```julia
julia> using GeometryBasics
[ Info: Precompiling GeometryBasics [5c1252a2-5f33-56bf-86c9-59e7332b4326]
ERROR: LoadError: LoadError: syntax: invalid keyword argument syntax "pointtype"
Stacktrace:
 [1] top-level scope at /home/daniel/.julia/dev/GeometryBasics/src/meshes.jl:138
 [2] include(::Module, ::String) at ./Base.jl:377
 [3] include(::String) at /home/daniel/.julia/dev/GeometryBasics/src/GeometryBasics.jl:1
 [4] top-level scope at /home/daniel/.julia/dev/GeometryBasics/src/GeometryBasics.jl:16
 [5] include(::Module, ::String) at ./Base.jl:377
 [6] top-level scope at none:2
 [7] eval at ./boot.jl:331 [inlined]
 [8] eval(::Expr) at ./client.jl:449
 [9] top-level scope at ./none:3
in expression starting at /home/daniel/.julia/dev/GeometryBasics/src/meshes.jl:138
in expression starting at /home/daniel/.julia/dev/GeometryBasics/src/GeometryBasics.jl:16
ERROR: Failed to precompile GeometryBasics [5c1252a2-5f33-56bf-86c9-59e7332b4326] to /home/daniel/.julia/compiled/v1.4/GeometryBasics/lB452_SCyYm.ji.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] compilecache(::Base.PkgId, ::String) at ./loading.jl:1272
 [3] _require(::Base.PkgId) at ./loading.jl:1029
 [4] require(::Base.PkgId) at ./loading.jl:927
 [5] require(::Module, ::Symbol) at ./loading.jl:922
 [6] eval(::Module, ::Any) at ./boot.jl:331
 [7] eval_user_input(::Any, ::REPL.REPLBackend) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [8] run_backend(::REPL.REPLBackend) at /home/daniel/.julia/packages/Revise/BqeJF/src/Revise.jl:1184
 [9] top-level scope at none:0

julia> versioninfo()
Julia Version 1.4.2
Commit 44fa15b150* (2020-05-23 18:35 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-8.0.1 (ORCJIT, skylake)
```