### PR TITLE
Replace f0 type suffix with f, rename Rect types

### DIFF
--- a/docs/src/decomposition.md
+++ b/docs/src/decomposition.md
@@ -9,13 +9,13 @@ This can be done for any arbitrary primitive, by overloading the following inter
 
 ```julia
 
-function GeometryBasics.coordinates(rect::Rect2D, nvertices=(2,2))
+function GeometryBasics.coordinates(rect::Rect2, nvertices=(2,2))
     mini, maxi = extrema(rect)
     xrange, yrange = LinRange.(mini, maxi, nvertices)
     return ivec(((x,y) for x in xrange, y in yrange))
 end
 
-function GeometryBasics.faces(rect::Rect2D, nvertices=(2, 2))
+function GeometryBasics.faces(rect::Rect2, nvertices=(2, 2))
     w, h = nvertices
     idx = LinearIndices(nvertices)
     quad(i, j) = QuadFace{Int}(idx[i, j], idx[i+1, j], idx[i+1, j+1], idx[i, j+1])
@@ -29,7 +29,7 @@ can also return any `AbstractArray`.
 With these methods defined, this constructor will magically work:
 
 ```julia
-rect = Rect2D(0.0, 0.0, 1.0, 1.0)
+rect = Rect2(0.0, 0.0, 1.0, 1.0)
 m = GeometryBasics.mesh(rect)
 ```
 If you want to set the `nvertices` argument, you need to wrap your primitive in a `Tesselation`

--- a/docs/src/decomposition.md
+++ b/docs/src/decomposition.md
@@ -48,7 +48,7 @@ But will actually not be an iterator anymore. Instead, the mesh constructor uses
 the `decompose` function, that will collect the result of coordinates and will
 convert it to a concrete element type:
 ```julia
-decompose(Point2f0, rect) == convert(Vector{Point2f0}, collect(coordinates(rect)))
+decompose(Point2f, rect) == convert(Vector{Point2f}, collect(coordinates(rect)))
 ```
 The element conversion is handled by `simplex_convert`, which also handles convert
 between different face types:
@@ -65,12 +65,12 @@ decompose(Point, rect) isa Vector{Point{2, Float64}}
 ```
 You can also pass the element type to `mesh`:
 ```julia
-m = GeometryBasics.mesh(rect, pointtype=Point2f0, facetype=QuadFace{Int})
+m = GeometryBasics.mesh(rect, pointtype=Point2f, facetype=QuadFace{Int})
 ```
 You can also set the uv and normal type for the mesh constructor, which will then
 calculate them for you, with the requested element type:
 ```julia
-m = GeometryBasics.mesh(rect, uv=Vec2f0, normaltype=Vec3f0)
+m = GeometryBasics.mesh(rect, uv=Vec2f, normaltype=Vec3f)
 ```
 
 As you can see, the normals are automatically calculated,
@@ -79,11 +79,11 @@ the same is true for texture coordinates. You can overload this behavior by over
 `decompose` works a bit different for normals/texturecoordinates, since they dont have their own element type.
 Instead, you can use `decompose` like this:
 ```julia
-decompose(UV(Vec2f0), rect)
-decompose(Normal(Vec3f0), rect)
+decompose(UV(Vec2f), rect)
+decompose(Normal(Vec3f), rect)
 # the short form for the above:
 decompose_uv(rect)
 decompose_normals(rect)
 ```
 You can also use `triangle_mesh`, `normal_mesh` and `uv_normal_mesh` to call the
-`mesh` constructor with predefined element types (Point2/3f0, Vec2/3f0), and the requested attributes.
+`mesh` constructor with predefined element types (Point2/3f, Vec2/3f), and the requested attributes.

--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -24,6 +24,8 @@ include("triangulation.jl")
 include("lines.jl")
 include("boundingboxes.jl")
 
+include("deprecated.jl")
+
 export AbstractGeometry, GeometryPrimitive
 export Mat, Point, Vec
 export LineFace, Polytope, Line, NgonFace, convert_simplex

--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -63,7 +63,7 @@ export uv_mesh, normal_mesh, uv_normal_mesh
 export height, origin, radius, width, widths, xwidth, yheight
 export HyperSphere, Circle, Sphere
 export Cylinder, Cylinder2, Cylinder3, Pyramid, extremity
-export HyperRectangle, Rect, Rect2D, Rect3D, IRect, IRect2D, IRect3D, FRect, FRect2D, FRect3D
+export HyperRectangle, Rect, Rect2, Rect3, Recti, Rect2i, Rect3i, Rectf, Rect2f, Rect3f
 export before, during, isinside, isoutside, meets, overlaps, intersects, finishes
 export centered, direction, area, volume, update
 export max_dist_dim, max_euclidean, max_euclideansq, min_dist_dim, min_euclidean

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -17,3 +17,14 @@ for i in 1:4
         @deprecate_binding $oldname $newname
     end
 end
+
+# Rect types
+@deprecate_binding Rect2D  Rect2
+@deprecate_binding Rect3D  Rect3
+@deprecate_binding FRect   Rectf
+@deprecate_binding FRect2D Rect2f
+@deprecate_binding FRect3D Rect3f
+@deprecate_binding IRect   Recti
+@deprecate_binding IRect2D Rect2i
+@deprecate_binding IRect3D Rect3i
+@deprecate_binding TRect   RectT

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,19 @@
+using Base: @deprecate_binding
+
+# Types ...f0 renamed to ...f
+@deprecate_binding Vecf0 Vecf
+@deprecate_binding Pointf0 Pointf
+for i in 1:4
+    for T in [:Point, :Vec]
+        oldname = Symbol("$T$(i)f0")
+        newname = Symbol("$T$(i)f")
+        @eval begin
+            @deprecate_binding $oldname $newname
+        end
+    end
+    oldname = Symbol("Mat$(i)f0")
+    newname = Symbol("Mat$(i)f")
+    @eval begin
+        @deprecate_binding $oldname $newname
+    end
+end

--- a/src/fixed_arrays.jl
+++ b/src/fixed_arrays.jl
@@ -121,31 +121,30 @@ abstract type AbstractPoint{Dim,T} <: StaticVector{Dim,T} end
 
 const Mat = SMatrix
 const VecTypes{N,T} = Union{StaticVector{N,T},NTuple{N,T}}
-const Vecf0{N} = Vec{N,Float32}
-const Pointf0{N} = Point{N,Float32}
+const Vecf{N} = Vec{N,Float32}
+const Pointf{N} = Point{N,Float32}
 Base.isnan(p::Union{AbstractPoint,Vec}) = any(x -> isnan(x), p)
 
-# Create constes like Mat4f0, Point2, Point2f0
 for i in 1:4
     for T in [:Point, :Vec]
         name = Symbol("$T$i")
-        namef0 = Symbol("$T$(i)f0")
+        namef = Symbol("$T$(i)f")
         @eval begin
             const $name = $T{$i}
-            const $namef0 = $T{$i,Float32}
+            const $namef = $T{$i,Float32}
             export $name
-            export $namef0
+            export $namef
         end
     end
     name = Symbol("Mat$i")
-    namef0 = Symbol("Mat$(i)f0")
+    namef = Symbol("Mat$(i)f")
     @eval begin
         const $name{T} = $Mat{$i,$i,T,$(i * i)}
-        const $namef0 = $name{Float32}
+        const $namef = $name{Float32}
         export $name
-        export $namef0
+        export $namef
     end
 end
 
 export Mat, Vec, Point, unit
-export Vecf0, Pointf0
+export Vecf, Pointf

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -43,7 +43,7 @@ To transport this information to the various decompose methods, you can wrap it
 in the Tesselation object e.g. like this:
 
 ```julia
-sphere = Sphere(Point3f0(0), 1)
+sphere = Sphere(Point3f(0), 1)
 m1 = mesh(sphere) # uses a default value for tesselation
 m2 = mesh(Tesselation(sphere, 64)) # uses 64 for tesselation
 length(coordinates(m1)) != length(coordinates(m2))
@@ -81,7 +81,7 @@ function texturecoordinates(tesselation::Tesselation)
 end
 
 ## Decompose methods
-# Dispatch type to make `decompose(UV{Vec2f0}, primitive)` work
+# Dispatch type to make `decompose(UV{Vec2f}, primitive)` work
 # and to pass through tesselation information
 
 # Types that can be converted to a mesh via the functions below
@@ -91,13 +91,13 @@ const Meshable{Dim,T} = Union{Tesselation{Dim,T},Mesh{Dim,T},AbstractPolygon{Dim
 
 struct UV{T} end
 UV(::Type{T}) where {T} = UV{T}()
-UV() = UV(Vec2f0)
+UV() = UV(Vec2f)
 struct UVW{T} end
 UVW(::Type{T}) where {T} = UVW{T}()
-UVW() = UVW(Vec3f0)
+UVW() = UVW(Vec3f)
 struct Normal{T} end
 Normal(::Type{T}) where {T} = Normal{T}()
-Normal() = Normal(Vec3f0)
+Normal() = Normal(Vec3f)
 
 function decompose(::Type{F}, primitive) where {F<:AbstractFace}
     f = faces(primitive)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -50,7 +50,7 @@ length(coordinates(m1)) != length(coordinates(m2))
 ```
 For grid based tesselation, you can also use a tuple:
 ```julia
-rect = Rect2D(0, 0, 1, 1)
+rect = Rect2(0, 0, 1, 1)
 Tesselation(rect, (5, 5))
 """
 struct Tesselation{Dim,T,Primitive,NGrid}

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -44,7 +44,7 @@ const GLPlainMesh3D = GLPlainMesh{3}
     UVMesh{Dim, T}
 
 PlainMesh with texture coordinates meta at each point.
-`uvmesh.uv isa AbstractVector{Vec2f0}`
+`uvmesh.uv isa AbstractVector{Vec2f}`
 """
 const UVMesh{Dim,T} = TriangleMesh{Dim,T,PointWithUV{Dim,T}}
 const GLUVMesh{Dim} = UVMesh{Dim,Float32}
@@ -55,7 +55,7 @@ const GLUVMesh3D = UVMesh{3}
     NormalMesh{Dim, T}
 
 PlainMesh with normals meta at each point.
-`normalmesh.normals isa AbstractVector{Vec3f0}`
+`normalmesh.normals isa AbstractVector{Vec3f}`
 """
 const NormalMesh{Dim,T} = TriangleMesh{Dim,T,PointWithNormal{Dim,T}}
 const GLNormalMesh{Dim} = NormalMesh{Dim,Float32}
@@ -66,8 +66,8 @@ const GLNormalMesh3D = GLNormalMesh{3}
     NormalUVMesh{Dim, T}
 
 PlainMesh with normals and uv meta at each point.
-`normalmesh.normals isa AbstractVector{Vec3f0}`
-`normalmesh.uv isa AbstractVector{Vec2f0}`
+`normalmesh.normals isa AbstractVector{Vec3f}`
+`normalmesh.uv isa AbstractVector{Vec2f}`
 """
 const NormalUVMesh{Dim,T} = TriangleMesh{Dim,T,PointWithUVNormal{Dim,T}}
 const GLNormalUVMesh{Dim} = NormalUVMesh{Dim,Float32}
@@ -78,8 +78,8 @@ const GLNormalUVMesh3D = GLNormalUVMesh{3}
     NormalUVWMesh{Dim, T}
 
 PlainMesh with normals and uvw (texture coordinates in 3D) meta at each point.
-`normalmesh.normals isa AbstractVector{Vec3f0}`
-`normalmesh.uvw isa AbstractVector{Vec3f0}`
+`normalmesh.normals isa AbstractVector{Vec3f}`
+`normalmesh.uvw isa AbstractVector{Vec3f}`
 """
 const NormalUVWMesh{Dim,T} = TriangleMesh{Dim,T,PointWithUVWNormal{Dim,T}}
 const GLNormalUVWMesh{Dim} = NormalUVWMesh{Dim,Float32}
@@ -176,17 +176,17 @@ function triangle_mesh(primitive::Meshable{N}; nvertices=nothing) where {N}
 end
 
 function uv_mesh(primitive::Meshable{N,T}) where {N,T}
-    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f0, facetype=GLTriangleFace)
+    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f, facetype=GLTriangleFace)
 end
 
 function uv_normal_mesh(primitive::Meshable{N}) where {N}
-    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f0, normaltype=Vec3f0,
+    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f, normaltype=Vec3f,
                 facetype=GLTriangleFace)
 end
 
 function normal_mesh(points::AbstractVector{<:AbstractPoint},
                      faces::AbstractVector{<:AbstractFace})
-    _points = decompose(Point3f0, points)
+    _points = decompose(Point3f, points)
     _faces = decompose(GLTriangleFace, faces)
     return Mesh(meta(_points; normals=normals(_points, _faces)), _faces)
 end
@@ -196,7 +196,7 @@ function normal_mesh(primitive::Meshable{N}; nvertices=nothing) where {N}
         @warn("nvertices argument deprecated. Wrap primitive in `Tesselation(primitive, nvertices)`")
         primitive = Tesselation(primitive, nvertices)
     end
-    return mesh(primitive; pointtype=Point{N,Float32}, normaltype=Vec3f0,
+    return mesh(primitive; pointtype=Point{N,Float32}, normaltype=Vec3f,
                 facetype=GLTriangleFace)
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -26,14 +26,14 @@ function _precompile_()
     @warnpcfail precompile(Tuple{typeof(*),HyperRectangle{2, Float32},Float32})   # time: 0.001057589
 
     if Base.VERSION >= v"1.6.0-DEV.1083"
-        @warnpcfail precompile(triangle_mesh, (Polygon{2, Float32, Point2f0, LineString{2, Float32, Point2f0,
-                                        Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f0, Point2f0}, TupleView{Tuple{Point2f0, Point2f0}, 2, 1, Vector{Point2f0}}, false}},
-                                        Vector{LineString{2, Float32, Point2f0, Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f0, Point2f0}, TupleView{Tuple{Point2f0, Point2f0}, 2, 1, Vector{Point2f0}}, false}}}},))
+        @warnpcfail precompile(triangle_mesh, (Polygon{2, Float32, Point2f, LineString{2, Float32, Point2f,
+                                        Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f, Point2f}, TupleView{Tuple{Point2f, Point2f}, 2, 1, Vector{Point2f}}, false}},
+                                        Vector{LineString{2, Float32, Point2f, Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f, Point2f}, TupleView{Tuple{Point2f, Point2f}, 2, 1, Vector{Point2f}}, false}}}},))
     else
-        @warnpcfail precompile(triangle_mesh, (Polygon{2, Float32, Point2f0, LineString{2, Float32, Point2f0,
-                                        Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f0, Point2f0}, TupleView{Tuple{Point2f0, Point2f0}, 2, 1, Vector{Point2f0}}}},
-                                        Vector{LineString{2, Float32, Point2f0, Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f0, Point2f0}, TupleView{Tuple{Point2f0, Point2f0}, 2, 1, Vector{Point2f0}}}}}},))
+        @warnpcfail precompile(triangle_mesh, (Polygon{2, Float32, Point2f, LineString{2, Float32, Point2f,
+                                        Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f, Point2f}, TupleView{Tuple{Point2f, Point2f}, 2, 1, Vector{Point2f}}}},
+                                        Vector{LineString{2, Float32, Point2f, Base.ReinterpretArray{Line{2, Float32}, 1, Tuple{Point2f, Point2f}, TupleView{Tuple{Point2f, Point2f}, 2, 1, Vector{Point2f}}}}}},))
     end
 
-    @warnpcfail precompile(split_intersections, (Vector{Point2f0},))
+    @warnpcfail precompile(split_intersections, (Vector{Point2f},))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -22,7 +22,7 @@ function _precompile_()
     @warnpcfail precompile(Tuple{typeof(decompose),Type{Point{2, Float32}},HyperRectangle{2, Float32}})   # time: 0.026609203
     @warnpcfail precompile(Tuple{Type{HyperRectangle{3, Float32}},HyperRectangle{2, Float32}})   # time: 0.023717888
     @warnpcfail precompile(Tuple{typeof(+),HyperRectangle{3, Float32},Point{3, Float32}})   # time: 0.006633118
-    @warnpcfail precompile(Tuple{Type{Rect2D{T} where T},Float32,Float32,Float32,Float32})   # time: 0.001636267
+    @warnpcfail precompile(Tuple{Type{Rect2{T} where T},Float32,Float32,Float32,Float32})   # time: 0.001636267
     @warnpcfail precompile(Tuple{typeof(*),HyperRectangle{2, Float32},Float32})   # time: 0.001057589
 
     if Base.VERSION >= v"1.6.0-DEV.1083"

--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -147,12 +147,12 @@ function Rect2D(xy::NamedTuple{(:x, :y)}, wh::NamedTuple{(:width, :height)})
 end
 
 function FRect3D(x::Tuple{Tuple{<:Number,<:Number},Tuple{<:Number,<:Number}})
-    return FRect3D(Vec3f0(x[1]..., 0), Vec3f0(x[2]..., 0))
+    return FRect3D(Vec3f(x[1]..., 0), Vec3f(x[2]..., 0))
 end
 
 function FRect3D(x::Tuple{Tuple{<:Number,<:Number,<:Number},
                           Tuple{<:Number,<:Number,<:Number}})
-    return FRect3D(Vec3f0(x[1]...), Vec3f0(x[2]...))
+    return FRect3D(Vec3f(x[1]...), Vec3f(x[2]...))
 end
 
 origin(prim::Rect) = prim.origin

--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -15,21 +15,21 @@ end
 # Constructors & typealiases
 
 const Rect{N,T} = HyperRectangle{N,T}
-const Rect2D{T} = Rect{2,T}
-const Rect3D{T} = Rect{3,T}
-const TRect{T} = Rect{N,T} where {N}
+const Rect2{T} = Rect{2,T}
+const Rect3{T} = Rect{3,T}
+const RectT{T} = Rect{N,T} where {N}
 
-const FRect{N} = Rect{N,Float32}
-const FRect2D = Rect2D{Float32}
-const FRect3D = Rect3D{Float32}
+const Rectf{N} = Rect{N,Float32}
+const Rect2f = Rect2{Float32}
+const Rect3f = Rect3{Float32}
 
-const IRect{N} = HyperRectangle{N,Int}
-const IRect2D = Rect2D{Int}
-const IRect3D = Rect3D{Int}
+const Recti{N} = HyperRectangle{N,Int}
+const Rect2i = Rect2{Int}
+const Rect3i = Rect3{Int}
 
 Rect() = Rect{2,Float32}()
 
-TRect{T}() where {T} = Rect{2,T}()
+RectT{T}() where {T} = Rect{2,T}()
 
 Rect{N}() where {N} = Rect{N,Float32}()
 
@@ -48,7 +48,7 @@ function Rect(v1::Vec{N,T1}, v2::Vec{N,T2}) where {N,T1,T2}
     return Rect{N,T}(Vec{N,T}(v1), Vec{N,T}(v2))
 end
 
-function TRect{T}(v1::VecTypes{N,T1}, v2::VecTypes{N,T2}) where {N,T,T1,T2}
+function RectT{T}(v1::VecTypes{N,T1}, v2::VecTypes{N,T2}) where {N,T,T1,T2}
     return if T <: Integer
         Rect{N,T}(round.(T, v1), round.(T, v2))
     else
@@ -84,75 +84,75 @@ width == Vec(1,2)
     return Expr(:call, :Rect, v1, v2)
 end
 
-Rect3D(a::Vararg{Number,6}) = Rect3D(Vec{3}(a[1], a[2], a[3]), Vec{3}(a[4], a[5], a[6]))
-Rect3D(args::Vararg{Number,4}) = Rect3D(Rect{2}(args...))
+Rect3(a::Vararg{Number,6}) = Rect3(Vec{3}(a[1], a[2], a[3]), Vec{3}(a[4], a[5], a[6]))
+Rect3(args::Vararg{Number,4}) = Rect3(Rect{2}(args...))
 #=
 From different args
 =#
 function (Rect)(args::Vararg{Number,4})
     args_prom = promote(args...)
-    return Rect2D{typeof(args_prom[1])}(args_prom...)
+    return Rect2{typeof(args_prom[1])}(args_prom...)
 end
 
-function (Rect2D)(args::Vararg{Number,4})
+function (Rect2)(args::Vararg{Number,4})
     args_prom = promote(args...)
-    return Rect2D{typeof(args_prom[1])}(args_prom...)
+    return Rect2{typeof(args_prom[1])}(args_prom...)
 end
 
 function (Rect{2,T})(args::Vararg{Number,4}) where {T}
     x, y, w, h = T <: Integer ? round.(T, args) : args
-    return Rect2D{T}(Vec{2,T}(x, y), Vec{2,T}(w, h))
+    return Rect2{T}(Vec{2,T}(x, y), Vec{2,T}(w, h))
 end
 
-function TRect{T}(args::Vararg{Number,4}) where {T}
+function RectT{T}(args::Vararg{Number,4}) where {T}
     x, y, w, h = T <: Integer ? round.(T, args) : args
-    return Rect2D{T}(Vec{2,T}(x, y), Vec{2,T}(w, h))
+    return Rect2{T}(Vec{2,T}(x, y), Vec{2,T}(w, h))
 end
 
-function FRect3D(x::Rect2D{T}) where {T}
+function Rect3f(x::Rect2{T}) where {T}
     return Rect{3,T}(Vec{3,T}(minimum(x)..., 0), Vec{3,T}(widths(x)..., 0.0))
 end
 
-function Rect2D{T}(a::Rect2D) where {T}
-    return Rect2D{T}(minimum(a), widths(a))
+function Rect2{T}(a::Rect2) where {T}
+    return Rect2{T}(minimum(a), widths(a))
 end
 
-function TRect{T}(a::Rect2D) where {T}
-    return Rect2D{T}(minimum(a), widths(a))
+function RectT{T}(a::Rect2) where {T}
+    return Rect2{T}(minimum(a), widths(a))
 end
 
 function Rect{N,T}(a::GeometryPrimitive) where {N,T}
     return Rect{N,T}(Vec{N,T}(minimum(a)), Vec{N,T}(widths(a)))
 end
 
-function Rect2D(xy::VecTypes{2}, w::Number, h::Number)
-    return Rect2D(xy..., w, h)
+function Rect2(xy::VecTypes{2}, w::Number, h::Number)
+    return Rect2(xy..., w, h)
 end
 
-function Rect2D(x::Number, y::Number, wh::VecTypes{2})
-    return Rect2D(x, y, wh...)
+function Rect2(x::Number, y::Number, wh::VecTypes{2})
+    return Rect2(x, y, wh...)
 end
 
-function TRect{T}(xy::VecTypes{2}, w::Number, h::Number) where {T}
-    return Rect2D{T}(xy..., w, h)
+function RectT{T}(xy::VecTypes{2}, w::Number, h::Number) where {T}
+    return Rect2{T}(xy..., w, h)
 end
 
-function TRect{T}(x::Number, y::Number, wh::VecTypes{2}) where {T}
-    return Rect2D{T}(x, y, wh...)
+function RectT{T}(x::Number, y::Number, wh::VecTypes{2}) where {T}
+    return Rect2{T}(x, y, wh...)
 end
 
 # TODO These are kinda silly
-function Rect2D(xy::NamedTuple{(:x, :y)}, wh::NamedTuple{(:width, :height)})
-    return Rect2D(xy.x, xy.y, wh.width, wh.height)
+function Rect2(xy::NamedTuple{(:x, :y)}, wh::NamedTuple{(:width, :height)})
+    return Rect2(xy.x, xy.y, wh.width, wh.height)
 end
 
-function FRect3D(x::Tuple{Tuple{<:Number,<:Number},Tuple{<:Number,<:Number}})
-    return FRect3D(Vec3f(x[1]..., 0), Vec3f(x[2]..., 0))
+function Rect3f(x::Tuple{Tuple{<:Number,<:Number},Tuple{<:Number,<:Number}})
+    return Rect3f(Vec3f(x[1]..., 0), Vec3f(x[2]..., 0))
 end
 
-function FRect3D(x::Tuple{Tuple{<:Number,<:Number,<:Number},
+function Rect3f(x::Tuple{Tuple{<:Number,<:Number,<:Number},
                           Tuple{<:Number,<:Number,<:Number}})
-    return FRect3D(Vec3f(x[1]...), Vec3f(x[2]...))
+    return Rect3f(Vec3f(x[1]...), Vec3f(x[2]...))
 end
 
 origin(prim::Rect) = prim.origin
@@ -165,7 +165,7 @@ width(prim::Rect) = prim.widths[1]
 height(prim::Rect) = prim.widths[2]
 
 volume(prim::HyperRectangle) = prod(prim.widths)
-area(prim::Rect2D) = volume(prim)
+area(prim::Rect2) = volume(prim)
 
 """
     split(rectangle, axis, value)
@@ -279,7 +279,7 @@ function Base.:(*)(rect::Rect, scaling::Union{Number,StaticVector})
 end
 
 # Enables rectangular indexing into a matrix
-function Base.to_indices(A::AbstractMatrix{T}, I::Tuple{Rect2D{IT}}) where {T,IT<:Integer}
+function Base.to_indices(A::AbstractMatrix{T}, I::Tuple{Rect2{IT}}) where {T,IT<:Integer}
     rect = I[1]
     mini = minimum(rect)
     wh = widths(rect)
@@ -515,33 +515,33 @@ centered(R::Type{Rect{N}}) where {N} = R(Vec{N,Float32}(-0.5), Vec{N,Float32}(1)
 centered(R::Type{Rect}) where {N} = R(Vec{2,Float32}(-0.5), Vec{2,Float32}(1))
 
 ##
-# Rect2D decomposition
+# Rect2 decomposition
 
-function faces(rect::Rect2D, nvertices=(2, 2))
+function faces(rect::Rect2, nvertices=(2, 2))
     w, h = nvertices
     idx = LinearIndices(nvertices)
     quad(i, j) = QuadFace{Int}(idx[i, j], idx[i + 1, j], idx[i + 1, j + 1], idx[i, j + 1])
     return ivec((quad(i, j) for i in 1:(w - 1), j in 1:(h - 1)))
 end
 
-function coordinates(rect::Rect2D, nvertices=(2, 2))
+function coordinates(rect::Rect2, nvertices=(2, 2))
     mini, maxi = extrema(rect)
     xrange, yrange = LinRange.(mini, maxi, nvertices)
     return ivec(((x, y) for x in xrange, y in yrange))
 end
 
-function texturecoordinates(rect::Rect2D, nvertices=(2, 2))
+function texturecoordinates(rect::Rect2, nvertices=(2, 2))
     xrange, yrange = LinRange.((0, 1), (1, 0), nvertices)
     return ivec(((x, y) for x in xrange, y in yrange))
 end
 
-function normals(rect::Rect2D, nvertices=(2, 2))
+function normals(rect::Rect2, nvertices=(2, 2))
     return Iterators.repeated((0, 0, 1), prod(nvertices))
 end
 
 ##
-# Rect3D decomposition
-function coordinates(rect::Rect3D)
+# Rect3 decomposition
+function coordinates(rect::Rect3)
     # TODO use n
     w = widths(rect)
     o = origin(rect)
@@ -552,11 +552,11 @@ function coordinates(rect::Rect3D)
     return ((x .* w .+ o) for x in points)
 end
 
-function texturecoordinates(rect::Rect3D)
-    return coordinates(Rect3D(0, 0, 0, 1, 1, 1))
+function texturecoordinates(rect::Rect3)
+    return coordinates(Rect3(0, 0, 0, 1, 1, 1))
 end
 
-function faces(rect::Rect3D)
+function faces(rect::Rect3)
     return QuadFace{Int}[(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16),
                          (17, 18, 19, 20), (21, 22, 23, 24),]
 end

--- a/src/primitives/spheres.jl
+++ b/src/primitives/spheres.jl
@@ -48,7 +48,7 @@ function coordinates(s::Circle, nvertices=64)
 end
 
 function texturecoordinates(s::Circle, nvertices=64)
-    return coordinates(Circle(Point2f0(0.5), 0.5f0), nvertices)
+    return coordinates(Circle(Point2f(0.5), 0.5f0), nvertices)
 end
 
 function coordinates(s::Sphere, nvertices=24)

--- a/src/viewtypes.jl
+++ b/src/viewtypes.jl
@@ -109,7 +109,7 @@ FaceView enables to link one array of points via a face array, to generate one
 abstract array of elements.
 E.g., this becomes possible:
 ```
-x = FaceView(rand(Point3f0, 10), TriangleFace[(1, 2, 3), (2, 4, 5), ...])
+x = FaceView(rand(Point3f, 10), TriangleFace[(1, 2, 3), (2, 4, 5), ...])
 x[1] isa Triangle == true
 x isa AbstractVector{<: Triangle} == true
 # This means we can use it as a mesh:

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -77,7 +77,7 @@ using Test, GeometryBasics
         @test m isa GLNormalMesh
 
         muv = uv_mesh(s)
-        @test Rect(Point.(texturecoordinates(muv))) == FRect2D(Vec2f(0), Vec2f(1.0))
+        @test Rect(Point.(texturecoordinates(muv))) == Rect2f(Vec2f(0), Vec2f(1.0))
     end
 end
 
@@ -134,7 +134,7 @@ end
                          (0.0, -1.0, 0.0), (0.0, -1.0, 0.0), (0.0, -1.0, 0.0),
                          (0.0, -1.0, 0.0),]
     n32 = map(Vec{3,Float32}, n64)
-    r = triangle_mesh(centered(Rect3D))
+    r = triangle_mesh(centered(Rect3))
     # @test normals(coordinates(r), GeometryBasics.faces(r)) == n32
     # @test normals(coordinates(r), GeometryBasics.faces(r)) == n64
 end
@@ -164,31 +164,31 @@ end
 end
 
 @testset "Rectangles" begin
-    rect = FRect2D(0, 7, 20, 3)
-    @test (rect + 4) == FRect2D(4, 11, 20, 3)
-    @test (rect + Vec(2, -2)) == FRect2D(2, 5, 20, 3)
+    rect = Rect2f(0, 7, 20, 3)
+    @test (rect + 4) == Rect2f(4, 11, 20, 3)
+    @test (rect + Vec(2, -2)) == Rect2f(2, 5, 20, 3)
 
-    @test (rect - 4) == FRect2D(-4, 3, 20, 3)
-    @test (rect - Vec(2, -2)) == FRect2D(-2, 9, 20, 3)
-
-    base = Vec3f(1, 2, 3)
-    wxyz = Vec3f(-2, 4, 2)
-    rect = FRect3D(base, wxyz)
-    @test (rect + 4) == FRect3D(base .+ 4, wxyz)
-    @test (rect + Vec(2, -2, 3)) == FRect3D(base .+ Vec(2, -2, 3), wxyz)
-
-    @test (rect - 4) == FRect3D(base .- 4, wxyz)
-    @test (rect - Vec(2, -2, 7)) == FRect3D(base .- Vec(2, -2, 7), wxyz)
-
-    rect = FRect2D(0, 7, 20, 3)
-    @test (rect * 4) == FRect2D(0, 7 * 4, 20 * 4, 3 * 4)
-    @test (rect * Vec(2, -2)) == FRect2D(0, -7 * 2, 20 * 2, -3 * 2)
+    @test (rect - 4) == Rect2f(-4, 3, 20, 3)
+    @test (rect - Vec(2, -2)) == Rect2f(-2, 9, 20, 3)
 
     base = Vec3f(1, 2, 3)
     wxyz = Vec3f(-2, 4, 2)
-    rect = FRect3D(base, wxyz)
-    @test (rect * 4) == FRect3D(base .* 4, wxyz .* 4)
-    @test (rect * Vec(2, -2, 3)) == FRect3D(base .* Vec(2, -2, 3), wxyz .* Vec(2, -2, 3))
+    rect = Rect3f(base, wxyz)
+    @test (rect + 4) == Rect3f(base .+ 4, wxyz)
+    @test (rect + Vec(2, -2, 3)) == Rect3f(base .+ Vec(2, -2, 3), wxyz)
+
+    @test (rect - 4) == Rect3f(base .- 4, wxyz)
+    @test (rect - Vec(2, -2, 7)) == Rect3f(base .- Vec(2, -2, 7), wxyz)
+
+    rect = Rect2f(0, 7, 20, 3)
+    @test (rect * 4) == Rect2f(0, 7 * 4, 20 * 4, 3 * 4)
+    @test (rect * Vec(2, -2)) == Rect2f(0, -7 * 2, 20 * 2, -3 * 2)
+
+    base = Vec3f(1, 2, 3)
+    wxyz = Vec3f(-2, 4, 2)
+    rect = Rect3f(base, wxyz)
+    @test (rect * 4) == Rect3f(base .* 4, wxyz .* 4)
+    @test (rect * Vec(2, -2, 3)) == Rect3f(base .* Vec(2, -2, 3), wxyz .* Vec(2, -2, 3))
 
     rect1 = Rect(Vec(0.0, 0.0), Vec(1.0, 2.0))
     rect2 = Rect(0.0, 0.0, 1.0, 2.0)
@@ -208,8 +208,8 @@ end
     @test width(prim) == 1.0
     @test height(prim) == 1.0
 
-    b1 = Rect2D(0.0, 0.0, 2.0, 2.0)
-    b2 = Rect2D(0, 0, 2, 2)
+    b1 = Rect2(0.0, 0.0, 2.0, 2.0)
+    b2 = Rect2(0, 0, 2, 2)
     @test isequal(b1, b2)
 
     pt = Point(1.0, 1.0)

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -2,7 +2,7 @@ using Test, GeometryBasics
 
 @testset "Cylinder" begin
     @testset "constructors" begin
-        o, extr, r = Point2f0(1, 2), Point2f0(3, 4), 5.0f0
+        o, extr, r = Point2f(1, 2), Point2f(3, 4), 5.0f0
         s = Cylinder(o, extr, r)
         @test typeof(s) == Cylinder{2,Float32}
         @test typeof(s) == Cylinder2{Float32}
@@ -13,7 +13,7 @@ using Test, GeometryBasics
         h = norm(o - extr)
         @test isapprox(height(s), h)
         #@test norm(direction(s) - Point{2,Float32}([2,2]./norm([1,2]-[3,4])))<1e-5
-        @test isapprox(direction(s), Point2f0(2, 2) ./ h)
+        @test isapprox(direction(s), Point2f(2, 2) ./ h)
         v1 = rand(Point{3,Float64})
         v2 = rand(Point{3,Float64})
         R = rand()
@@ -30,14 +30,14 @@ using Test, GeometryBasics
 
     @testset "decompose" begin
 
-        o, extr, r = Point2f0(1, 2), Point2f0(3, 4), 5.0f0
+        o, extr, r = Point2f(1, 2), Point2f(3, 4), 5.0f0
         s = Cylinder(o, extr, r)
         positions = Point{3,Float32}[(-0.7677671, 3.767767, 0.0),
                                      (2.767767, 0.23223293, 0.0),
                                      (0.23223293, 4.767767, 0.0),
                                      (3.767767, 1.2322329, 0.0), (1.2322329, 5.767767, 0.0),
                                      (4.767767, 2.232233, 0.0)]
-        @test decompose(Point3f0, Tesselation(s, (2, 3))) ≈ positions
+        @test decompose(Point3f, Tesselation(s, (2, 3))) ≈ positions
 
         FT = TriangleFace{Int}
         faces = FT[(1, 2, 4), (1, 4, 3), (3, 4, 6), (3, 6, 5)]
@@ -77,7 +77,7 @@ using Test, GeometryBasics
         @test m isa GLNormalMesh
 
         muv = uv_mesh(s)
-        @test Rect(Point.(texturecoordinates(muv))) == FRect2D(Vec2f0(0), Vec2f0(1.0))
+        @test Rect(Point.(texturecoordinates(muv))) == FRect2D(Vec2f(0), Vec2f(1.0))
     end
 end
 
@@ -86,7 +86,7 @@ end
     pt_expa = Point{2,Int}[(0, 0), (1, 0), (0, 1), (1, 1)]
     @test decompose(Point{2,Int}, a) == pt_expa
     mesh = normal_mesh(a)
-    @test decompose(Point2f0, mesh) == pt_expa
+    @test decompose(Point2f, mesh) == pt_expa
 
     b = Rect(Vec(1, 1, 1), Vec(1, 1, 1))
     pt_expb = Point{3,Int64}[[1, 1, 1], [1, 1, 2], [1, 2, 2], [1, 2, 1], [1, 1, 1],
@@ -140,7 +140,7 @@ end
 end
 
 @testset "HyperSphere" begin
-    sphere = Sphere{Float32}(Point3f0(0), 1.0f0)
+    sphere = Sphere{Float32}(Point3f(0), 1.0f0)
 
     points = decompose(Point, Tesselation(sphere, 3))
     point_target = Point{3,Float32}[[0.0, 0.0, 1.0], [1.0, 0.0, 6.12323e-17],
@@ -155,12 +155,12 @@ end
     face_target = TriangleFace{Int}[[1, 2, 5], [1, 5, 4], [2, 3, 6], [2, 6, 5], [4, 5, 8],
                                     [4, 8, 7], [5, 6, 9], [5, 9, 8]]
     @test f == face_target
-    circle = Circle(Point2f0(0), 1.0f0)
-    points = decompose(Point2f0, Tesselation(circle, 20))
+    circle = Circle(Point2f(0), 1.0f0)
+    points = decompose(Point2f, Tesselation(circle, 20))
     @test length(points) == 20
     tess_circle = Tesselation(circle, 32)
     mesh = triangle_mesh(tess_circle)
-    @test decompose(Point2f0, mesh) ≈ decompose(Point2f0, tess_circle)
+    @test decompose(Point2f, mesh) ≈ decompose(Point2f, tess_circle)
 end
 
 @testset "Rectangles" begin
@@ -171,8 +171,8 @@ end
     @test (rect - 4) == FRect2D(-4, 3, 20, 3)
     @test (rect - Vec(2, -2)) == FRect2D(-2, 9, 20, 3)
 
-    base = Vec3f0(1, 2, 3)
-    wxyz = Vec3f0(-2, 4, 2)
+    base = Vec3f(1, 2, 3)
+    wxyz = Vec3f(-2, 4, 2)
     rect = FRect3D(base, wxyz)
     @test (rect + 4) == FRect3D(base .+ 4, wxyz)
     @test (rect + Vec(2, -2, 3)) == FRect3D(base .+ Vec(2, -2, 3), wxyz)
@@ -184,8 +184,8 @@ end
     @test (rect * 4) == FRect2D(0, 7 * 4, 20 * 4, 3 * 4)
     @test (rect * Vec(2, -2)) == FRect2D(0, -7 * 2, 20 * 2, -3 * 2)
 
-    base = Vec3f0(1, 2, 3)
-    wxyz = Vec3f0(-2, 4, 2)
+    base = Vec3f(1, 2, 3)
+    wxyz = Vec3f(-2, 4, 2)
     rect = FRect3D(base, wxyz)
     @test (rect * 4) == FRect3D(base .* 4, wxyz .* 4)
     @test (rect * Vec(2, -2, 3)) == FRect3D(base .* Vec(2, -2, 3), wxyz .* Vec(2, -2, 3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using GeometryBasics: attributes
 @testset "GeometryBasics" begin
 
 @testset "algorithms" begin
-    cube = Rect(Vec3f0(-0.5), Vec3f0(1))
+    cube = Rect(Vec3f(-0.5), Vec3f(1))
     cube_faces = decompose(TriangleFace{Int}, faces(cube))
     cube_vertices = decompose(Point{3,Float32}, cube)
     @test area(cube_vertices, cube_faces) == 6
@@ -17,13 +17,13 @@ using GeometryBasics: attributes
     rect = Rect(1, 2, 7.5, 2.0)
     @test GeometryBasics.area(rect) ≈ 15
 
-    points_cwise = Point2f0[(0,0), (0,1), (1,1)]
-    points_ccwise = Point2f0[(0,0), (1,0), (1,1)]
+    points_cwise = Point2f[(0,0), (0,1), (1,1)]
+    points_ccwise = Point2f[(0,0), (1,0), (1,1)]
     @test area(points_cwise) ≈ -0.5
     @test area(points_ccwise) ≈ 0.5
     @test area(OffsetArray(points_cwise, -2)) ≈ -0.5
 
-    points3d = Point3f0[(0,0,0), (0,0,1), (0,1,1)]
+    points3d = Point3f[(0,0,0), (0,0,1), (0,1,1)]
     @test area(OffsetArray(points3d, -2)) ≈ 0.5
 
     pm2d = [PointMeta(0.0, 0.0, a=:d), PointMeta(0.0, 1.0, a=:e), PointMeta(1.0, 0.0, a=:f)]
@@ -153,7 +153,7 @@ end
     end
 
     @testset "Mesh with metadata" begin
-       m = triangle_mesh(Sphere(Point3f0(0), 1))
+       m = triangle_mesh(Sphere(Point3f(0), 1))
        m_meta = MeshMeta(m; boundingbox=Rect(1.0, 1.0, 2.0, 2.0))
        @test meta(m_meta) === (boundingbox = Rect(1.0, 1.0, 2.0, 2.0),)
        @test metafree(m_meta) === m
@@ -402,10 +402,10 @@ end
         mesh = Mesh(points, faces)
         @test mesh == [Tetrahedron(points...)]
 
-        points = rand(Point3f0, 8)
+        points = rand(Point3f, 8)
         tfaces = [GLTriangleFace(1, 2, 3), GLTriangleFace(5, 6, 7)]
-        normals = rand(Vec3f0, 8)
-        uv = rand(Vec2f0, 8)
+        normals = rand(Vec3f, 8)
+        uv = rand(Vec2f, 8)
         mesh = Mesh(points, tfaces)
         meshuv = Mesh(meta(points; uv=uv), tfaces)
         meshuvnormal = Mesh(meta(points; normals=normals, uv=uv), tfaces)
@@ -415,10 +415,10 @@ end
         @test meshuvnormal isa GLNormalUVMesh3D
 
         t = Tesselation(FRect2D(0, 0, 2, 2), (30, 30))
-        m = GeometryBasics.mesh(t, pointtype=Point3f0, facetype=QuadFace{Int})
+        m = GeometryBasics.mesh(t, pointtype=Point3f, facetype=QuadFace{Int})
         m2 = GeometryBasics.mesh(m, facetype=QuadFace{GLIndex})
         @test GeometryBasics.faces(m2) isa Vector{QuadFace{GLIndex}}
-        @test GeometryBasics.coordinates(m2) isa Vector{Point3f0}
+        @test GeometryBasics.coordinates(m2) isa Vector{Point3f}
 
     end
 
@@ -455,39 +455,39 @@ end
 end
 
 @testset "decompose/triangulation" begin
-    primitive = Sphere(Point3f0(0), 1)
+    primitive = Sphere(Point3f(0), 1)
     @test ndims(primitive) === 3
     mesh = triangle_mesh(primitive)
-    @test decompose(Point, mesh) isa Vector{Point3f0}
-    @test decompose(Point, primitive) isa Vector{Point3f0}
+    @test decompose(Point, mesh) isa Vector{Point3f}
+    @test decompose(Point, primitive) isa Vector{Point3f}
 
     primitive = Rect2D(0, 0, 1, 1)
     mesh = triangle_mesh(primitive)
 
-    @test decompose(Point, mesh) isa Vector{Point2f0}
+    @test decompose(Point, mesh) isa Vector{Point2f}
     @test decompose(Point, primitive) isa Vector{Point2{Int}}
 
     primitive = Rect3D(0, 0, 0, 1, 1, 1)
     triangle_mesh(primitive)
 
-    primitive = Sphere(Point3f0(0), 1)
+    primitive = Sphere(Point3f(0), 1)
     m_normal = normal_mesh(primitive)
-    @test normals(m_normal) isa Vector{Vec3f0}
+    @test normals(m_normal) isa Vector{Vec3f}
     primitive = Rect2D(0, 0, 1, 1)
     m_normal = normal_mesh(primitive)
-    @test normals(m_normal) isa Vector{Vec3f0}
+    @test normals(m_normal) isa Vector{Vec3f}
     primitive = Rect3D(0, 0, 0, 1, 1, 1)
     m_normal = normal_mesh(primitive)
-    @test normals(m_normal) isa Vector{Vec3f0}
+    @test normals(m_normal) isa Vector{Vec3f}
 
-    points = decompose(Point2f0, Circle(Point2f0(0), 1))
+    points = decompose(Point2f, Circle(Point2f(0), 1))
     tmesh = triangle_mesh(points)
     @test normals(tmesh) == nothing
 
-    m = GeometryBasics.mesh(Sphere(Point3f0(0), 1))
+    m = GeometryBasics.mesh(Sphere(Point3f(0), 1))
     @test normals(m) == nothing
     m_normals = pointmeta(m, Normal())
-    @test normals(m_normals) isa Vector{Vec3f0}
+    @test normals(m_normals) isa Vector{Vec3f}
 
     @test texturecoordinates(m) == nothing
     r2 = Rect2D(0.0, 0.0, 1.0, 1.0)
@@ -497,7 +497,7 @@ end
     uv = decompose_uv(m)
     @test Rect(Point.(uv)) == Rect(0, 0, 1, 1)
 
-    points = decompose(Point2f0, Circle(Point2f0(0), 1))
+    points = decompose(Point2f, Circle(Point2f(0), 1))
     m = GeometryBasics.mesh(points)
     @test coordinates(m) === points
 
@@ -520,19 +520,19 @@ end
 end
 
 @testset "mesh" begin
-    primitive = Triangle(Point2f0(0), Point2f0(1), Point2f0(1,0))
+    primitive = Triangle(Point2f(0), Point2f(1), Point2f(1,0))
     m = GeometryBasics.mesh(primitive)
     @test length(faces(m)) == 1
 end
 
 @testset "convert mesh + meta" begin
-    m = uv_normal_mesh(Circle(Point2f0(0), 1f0))
+    m = uv_normal_mesh(Circle(Point2f(0), 1f0))
     # for 2D primitives we dont actually calculate normals
     @test !hasproperty(m, :normals)
 end
 
 @testset "convert mesh + meta" begin
-    m = uv_normal_mesh(FRect3D(Vec3f0(-1), Vec3f0(1, 2, 3)))
+    m = uv_normal_mesh(FRect3D(Vec3f(-1), Vec3f(1, 2, 3)))
     m_normal = normal_mesh(m)
     # make sure we don't loose the uv
     @test hasproperty(m_normal, :uv)
@@ -542,7 +542,7 @@ end
     @test m.normals === m_normal.normals
     @test m.uv === m_normal.uv
 
-    m = GeometryBasics.mesh(FRect3D(Vec3f0(-1), Vec3f0(1, 2, 3));
+    m = GeometryBasics.mesh(FRect3D(Vec3f(-1), Vec3f(1, 2, 3));
                             uv=Vec2{Float64}, normaltype=Vec3{Float64}, pointtype=Point3{Float64})
     m_normal = normal_mesh(m)
     @test hasproperty(m_normal, :uv)
@@ -554,7 +554,7 @@ end
 
 @testset "modifying meta" begin
     xx = rand(10)
-    points = rand(Point3f0, 10)
+    points = rand(Point3f, 10)
     m = GeometryBasics.Mesh(meta(points, xx=xx), GLTriangleFace[(1,2,3), (3,4,5)])
     color = rand(10)
     m = pointmeta(m; color=color)
@@ -576,13 +576,13 @@ end
     @test xxpopt === xx
 
     @testset "creating meta" begin
-        x = Point3f0[(1,3,4)]
+        x = Point3f[(1,3,4)]
         # no meta gets added, so should stay the same
         @test meta(x) === x
         @test meta(x, value=[1]).position === x
     end
-    pos = Point2f0[(10, 2)]
-    m = Mesh(meta(pos, uv=[Vec2f0(1, 1)]), [GLTriangleFace(1, 1, 1)])
+    pos = Point2f[(10, 2)]
+    m = Mesh(meta(pos, uv=[Vec2f(1, 1)]), [GLTriangleFace(1, 1, 1)])
     @test m.position === pos
 end
 
@@ -597,16 +597,16 @@ end
 
     tmesh = triangle_mesh(m)
     @test tmesh isa GLPlainMesh
-    @test coordinates(tmesh) === decompose(Point3f0, tmesh)
+    @test coordinates(tmesh) === decompose(Point3f, tmesh)
 
     nmesh = normal_mesh(m)
     @test nmesh isa GLNormalMesh
-    @test metafree(coordinates(nmesh)) === decompose(Point3f0, nmesh)
+    @test metafree(coordinates(nmesh)) === decompose(Point3f, nmesh)
     @test normals(nmesh) === decompose_normals(nmesh)
 
-    m = GeometryBasics.mesh(s, pointtype=Point3f0)
+    m = GeometryBasics.mesh(s, pointtype=Point3f)
     @test m isa Mesh{3, Float32}
-    @test coordinates(m) isa Vector{Point3f0}
+    @test coordinates(m) isa Vector{Point3f}
     @test GeometryBasics.faces(m) isa Vector{GLTriangleFace}
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -414,7 +414,7 @@ end
         @test meshuv isa GLUVMesh3D
         @test meshuvnormal isa GLNormalUVMesh3D
 
-        t = Tesselation(FRect2D(0, 0, 2, 2), (30, 30))
+        t = Tesselation(Rect2f(0, 0, 2, 2), (30, 30))
         m = GeometryBasics.mesh(t, pointtype=Point3f, facetype=QuadFace{Int})
         m2 = GeometryBasics.mesh(m, facetype=QuadFace{GLIndex})
         @test GeometryBasics.faces(m2) isa Vector{QuadFace{GLIndex}}
@@ -461,22 +461,22 @@ end
     @test decompose(Point, mesh) isa Vector{Point3f}
     @test decompose(Point, primitive) isa Vector{Point3f}
 
-    primitive = Rect2D(0, 0, 1, 1)
+    primitive = Rect2(0, 0, 1, 1)
     mesh = triangle_mesh(primitive)
 
     @test decompose(Point, mesh) isa Vector{Point2f}
     @test decompose(Point, primitive) isa Vector{Point2{Int}}
 
-    primitive = Rect3D(0, 0, 0, 1, 1, 1)
+    primitive = Rect3(0, 0, 0, 1, 1, 1)
     triangle_mesh(primitive)
 
     primitive = Sphere(Point3f(0), 1)
     m_normal = normal_mesh(primitive)
     @test normals(m_normal) isa Vector{Vec3f}
-    primitive = Rect2D(0, 0, 1, 1)
+    primitive = Rect2(0, 0, 1, 1)
     m_normal = normal_mesh(primitive)
     @test normals(m_normal) isa Vector{Vec3f}
-    primitive = Rect3D(0, 0, 0, 1, 1, 1)
+    primitive = Rect3(0, 0, 0, 1, 1, 1)
     m_normal = normal_mesh(primitive)
     @test normals(m_normal) isa Vector{Vec3f}
 
@@ -490,9 +490,9 @@ end
     @test normals(m_normals) isa Vector{Vec3f}
 
     @test texturecoordinates(m) == nothing
-    r2 = Rect2D(0.0, 0.0, 1.0, 1.0)
+    r2 = Rect2(0.0, 0.0, 1.0, 1.0)
     @test iterate(texturecoordinates(r2)) == ((0.0, 1.0), ((0.0, 2), (1.0, 2)))
-    r3 = Rect3D(0.0, 0.0, 1.0, 1.0, 2.0, 2.0)
+    r3 = Rect3(0.0, 0.0, 1.0, 1.0, 2.0, 2.0)
     @test iterate(texturecoordinates(r3)) == ([0, 0, 0], 2)
     uv = decompose_uv(m)
     @test Rect(Point.(uv)) == Rect(0, 0, 1, 1)
@@ -532,7 +532,7 @@ end
 end
 
 @testset "convert mesh + meta" begin
-    m = uv_normal_mesh(FRect3D(Vec3f(-1), Vec3f(1, 2, 3)))
+    m = uv_normal_mesh(Rect3f(Vec3f(-1), Vec3f(1, 2, 3)))
     m_normal = normal_mesh(m)
     # make sure we don't loose the uv
     @test hasproperty(m_normal, :uv)
@@ -542,7 +542,7 @@ end
     @test m.normals === m_normal.normals
     @test m.uv === m_normal.uv
 
-    m = GeometryBasics.mesh(FRect3D(Vec3f(-1), Vec3f(1, 2, 3));
+    m = GeometryBasics.mesh(Rect3f(Vec3f(-1), Vec3f(1, 2, 3));
                             uv=Vec2{Float64}, normaltype=Vec3{Float64}, pointtype=Point3{Float64})
     m_normal = normal_mesh(m)
     @test hasproperty(m_normal, :uv)


### PR DESCRIPTION
This implements the change proposed in https://github.com/JuliaGeometry/GeometryBasics.jl/issues/61 . If the GeometryBasics maintainers are OK with this, I'll make PRs for all the dependents.