### PR TITLE
Fix type instability in normals

### DIFF
--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -107,7 +107,12 @@ Compute all vertex normals.
 """
 function normals(vertices::AbstractVector{<:AbstractPoint{3,T}}, faces::AbstractVector{F};
                  normaltype=Vec{3,T}) where {T,F<:NgonFace}
-    normals_result = zeros(normaltype, length(vertices)) # initilize with same type as verts but with 0
+    return normals(vertices, faces, normaltype)
+end
+
+function normals(vertices::AbstractVector{<:AbstractPoint{3,T}}, faces::AbstractVector{F},
+                 ::Type{N}) where {T,F<:NgonFace,N}
+    normals_result = zeros(N, length(vertices)) # initilize with same type as verts but with 0
     for face in faces
         v = metafree.(vertices[face])
         # we can get away with two edges since faces are planar.

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -112,7 +112,7 @@ end
 
 function normals(vertices::AbstractVector{<:AbstractPoint{3,T}}, faces::AbstractVector{F},
                  ::Type{N}) where {T,F<:NgonFace,N}
-    normals_result = zeros(N, length(vertices)) # initilize with same type as verts but with 0
+    normals_result = zeros(N, length(vertices))
     for face in faces
         v = metafree.(vertices[face])
         # we can get away with two edges since faces are planar.


### PR DESCRIPTION
I noticed `mesh` in Makie sometimes take a long time to plot. This is especially apparent when animating a large, growing mesh. The problem is a type instability in `normals`, which this PR fixes.

The only change I made is that I added a function barrier. This greatly improves performance (see below).

MWE:
```julia
using BenchmarkTools
using GeometryBasics

points = [Point(rand(), rand(), rand()) for _ in 1:200]
faces = typeof(GLTriangleFace(1,2,3))[]
for u in 1:200, v in u+1:200, w in v+1:200
    push!(faces, GLTriangleFace(u, v, w))
end

# Before this PR
@benchmark normals(points, faces) samples=10 seconds=10
# BenchmarkTools.Trial:
#  memory estimate:  761.56 MiB
#  allocs estimate:  14447403
#  --------------
#  minimum time:     607.730 ms (12.67% GC)
#  median time:      617.510 ms (12.60% GC)
#  mean time:        619.235 ms (12.62% GC)
#  maximum time:     637.565 ms (12.63% GC)
#  --------------
#  samples:          10
#  evals/sample:     1

# After this PR
@benchmark normals(points, faces) samples=10 seconds=10
# BenchmarkTools.Trial:
#  memory estimate:  400.82 MiB
#  allocs estimate:  2626801
#  --------------
#  minimum time:     156.252 ms (8.53% GC)
#  median time:      163.279 ms (8.52% GC)
#  mean time:        167.465 ms (8.39% GC)
#  maximum time:     193.659 ms (7.38% GC)
#  --------------
#  samples:          10
#  evals/sample:     1
```