### PR TITLE
Cleanup Vec aliases

### DIFF
--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -30,7 +30,7 @@ export AbstractPoint, Point, PointMeta, PointWithUV
 
 # vectors
 export Vec, Vec2, Vec3, Vec2f, Vec3f
-export euclidbasis, constant
+export vunit, vfill
 
 # geometries
 export AbstractGeometry, GeometryPrimitive

--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -6,6 +6,8 @@ using EarCut_jll
 using Base: @propagate_inbounds
 
 include("fixed_arrays.jl")
+include("vectors.jl")
+include("matrices.jl")
 include("offsetintegers.jl")
 include("basic_types.jl")
 
@@ -25,6 +27,10 @@ include("boundingboxes.jl")
 
 # points
 export AbstractPoint, Point, PointMeta, PointWithUV
+
+# vectors
+export Vec, Vec2, Vec3, Vec2f, Vec3f
+export euclidbasis, constant
 
 # geometries
 export AbstractGeometry, GeometryPrimitive
@@ -71,9 +77,6 @@ export self_intersections, split_intersections
 
 # bounding boxes
 export boundbox
-
-# helper types
-export Vec, Mat
 
 if Base.VERSION >= v"1.4.2"
     include("precompile.jl")

--- a/src/fixed_arrays.jl
+++ b/src/fixed_arrays.jl
@@ -1,11 +1,3 @@
-
-function unit(::Type{T}, i::Integer) where {T<:StaticVector}
-    tup = ntuple(Val(length(T))) do j
-        return ifelse(i == j, 1, 0)
-    end
-    return T(tup)
-end
-
 macro fixed_vector(name, parent)
     expr = quote
         struct $(name){S,T} <: $(parent){S,T}
@@ -118,15 +110,10 @@ end
 abstract type AbstractPoint{Dim,T} <: StaticVector{Dim,T} end
 @fixed_vector Point AbstractPoint
 
-const Vec = SVector
-const Mat = SMatrix
-const Vecf0{N} = Vec{N,Float32}
 const Pointf0{N} = Point{N,Float32}
-Base.isnan(p::Union{AbstractPoint,Vec}) = any(x -> isnan(x), p)
 
-#Create constes like Mat4f0, Point2, Point2f0
 for i in 1:4
-    for T in [:Point, :Vec]
+    for T in [:Point]
         name = Symbol("$T$i")
         namef0 = Symbol("$T$(i)f0")
         @eval begin
@@ -136,14 +123,6 @@ for i in 1:4
             export $namef0
         end
     end
-    name = Symbol("Mat$i")
-    namef0 = Symbol("Mat$(i)f0")
-    @eval begin
-        const $name{T} = $Mat{$i,$i,T,$(i * i)}
-        const $namef0 = $name{Float32}
-        export $name
-        export $namef0
-    end
 end
 
-export Vecf0, Pointf0
+export Pointf0

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -81,7 +81,7 @@ function texturecoordinates(tesselation::Tesselation)
 end
 
 ## Decompose methods
-# Dispatch type to make `decompose(UV{Vec2f0}, primitive)` work
+# Dispatch type to make `decompose(UV{Vec2f}, primitive)` work
 # and to pass through tesselation information
 
 # Types that can be converted to a mesh via the functions below
@@ -91,13 +91,13 @@ const Meshable{Dim,T} = Union{Tesselation{Dim,T},Mesh{Dim,T},AbstractPolygon{Dim
 
 struct UV{T} end
 UV(::Type{T}) where {T} = UV{T}()
-UV() = UV(Vec2f0)
+UV() = UV(Vec2f)
 struct UVW{T} end
 UVW(::Type{T}) where {T} = UVW{T}()
-UVW() = UVW(Vec3f0)
+UVW() = UVW(Vec3f)
 struct Normal{T} end
 Normal(::Type{T}) where {T} = Normal{T}()
-Normal() = Normal(Vec3f0)
+Normal() = Normal(Vec3f)
 
 function decompose(::Type{F}, primitive) where {F<:AbstractFace}
     f = faces(primitive)

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -1,0 +1,10 @@
+"""
+    Mat{M,N,T}
+
+A `M` by `N` matrix with entries of type `T`.
+
+## Notes
+
+- A `Mat` is `SMatrix` from StaticArrays.jl
+"""
+const Mat = SMatrix

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -44,7 +44,7 @@ const GLPlainMesh3D = GLPlainMesh{3}
     UVMesh{Dim, T}
 
 PlainMesh with texture coordinates meta at each point.
-`uvmesh.uv isa AbstractVector{Vec2f0}`
+`uvmesh.uv isa AbstractVector{Vec2f}`
 """
 const UVMesh{Dim,T} = TriangleMesh{Dim,T,PointWithUV{Dim,T}}
 const GLUVMesh{Dim} = UVMesh{Dim,Float32}
@@ -55,7 +55,7 @@ const GLUVMesh3D = UVMesh{3}
     NormalMesh{Dim, T}
 
 PlainMesh with normals meta at each point.
-`normalmesh.normals isa AbstractVector{Vec3f0}`
+`normalmesh.normals isa AbstractVector{Vec3f}`
 """
 const NormalMesh{Dim,T} = TriangleMesh{Dim,T,PointWithNormal{Dim,T}}
 const GLNormalMesh{Dim} = NormalMesh{Dim,Float32}
@@ -66,8 +66,8 @@ const GLNormalMesh3D = GLNormalMesh{3}
     NormalUVMesh{Dim, T}
 
 PlainMesh with normals and uv meta at each point.
-`normalmesh.normals isa AbstractVector{Vec3f0}`
-`normalmesh.uv isa AbstractVector{Vec2f0}`
+`normalmesh.normals isa AbstractVector{Vec3f}`
+`normalmesh.uv isa AbstractVector{Vec2f}`
 """
 const NormalUVMesh{Dim,T} = TriangleMesh{Dim,T,PointWithUVNormal{Dim,T}}
 const GLNormalUVMesh{Dim} = NormalUVMesh{Dim,Float32}
@@ -78,8 +78,8 @@ const GLNormalUVMesh3D = GLNormalUVMesh{3}
     NormalUVWMesh{Dim, T}
 
 PlainMesh with normals and uvw (texture coordinates in 3D) meta at each point.
-`normalmesh.normals isa AbstractVector{Vec3f0}`
-`normalmesh.uvw isa AbstractVector{Vec3f0}`
+`normalmesh.normals isa AbstractVector{Vec3f}`
+`normalmesh.uvw isa AbstractVector{Vec3f}`
 """
 const NormalUVWMesh{Dim,T} = TriangleMesh{Dim,T,PointWithUVWNormal{Dim,T}}
 const GLNormalUVWMesh{Dim} = NormalUVWMesh{Dim,Float32}
@@ -170,11 +170,11 @@ function triangle_mesh(primitive::Meshable{N}; nvertices=nothing) where {N}
 end
 
 function uv_mesh(primitive::Meshable{N,T}) where {N,T}
-    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f0, facetype=GLTriangleFace)
+    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f, facetype=GLTriangleFace)
 end
 
 function uv_normal_mesh(primitive::Meshable{N}) where {N}
-    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f0, normaltype=Vec3f0,
+    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f, normaltype=Vec3f,
                 facetype=GLTriangleFace)
 end
 
@@ -190,7 +190,7 @@ function normal_mesh(primitive::Meshable{N}; nvertices=nothing) where {N}
         @warn("nvertices argument deprecated. Wrap primitive in `Tesselation(primitive, nvertices)`")
         primitive = Tesselation(primitive, nvertices)
     end
-    return mesh(primitive; pointtype=Point{N,Float32}, normaltype=Vec3f0,
+    return mesh(primitive; pointtype=Point{N,Float32}, normaltype=Vec3f,
                 facetype=GLTriangleFace)
 end
 

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -1,0 +1,64 @@
+"""
+    Vec{N,T}
+
+A vector in `N`-dimensional space with coordinates of type
+`T` representing a direction with magnitude. A vector can
+be obtained by subtracting two [`Point`](@ref) objects:
+
+## Example
+
+```julia
+A = Point(0.0, 0.0)
+B = Point(1.0, 0.0)
+v = B - A
+```
+
+### Notes
+
+- A `Vec` is a `SVector` from StaticArrays.jl
+- Type aliases are `Vec2`, `Vec3`, `Vec2f`, `Vec3f`
+"""
+const Vec = SVector
+
+# type aliases for convenience
+const Vec2  = Vec{2,Float64}
+const Vec3  = Vec{3,Float64}
+const Vec2f = Vec{2,Float32}
+const Vec3f = Vec{3,Float32}
+
+"""
+    euclidbasis(VecType, i)
+
+Return the `i`-th vector in the Euclidean basis
+as a vector with type `VecType`.
+
+## Example
+
+```julia
+euclidbasis(Vec3, 1) == [1.0, 0.0, 0.0]
+euclidbasis(Vec3, 2) == [0.0, 1.0, 0.0]
+euclidbasis(Vec3, 3) == [0.0, 0.0, 1.0]
+```
+"""
+function euclidbasis(VecType::Type, i::Integer)
+    N = length(VecType)
+    T = eltype(VecType)
+    VecType(ntuple(j->ifelse(i==j, one(T), zero(T)), N))
+end
+
+"""
+    constant(VecType, v)
+
+Return the vector of type `VecType` with all
+coordinates equal to `v`.
+
+## Example
+
+```julia
+constant(Vec2, 3) == [3.0, 3.0]
+constant(Vec2f, 0) == [0.0f0, 0.0f0]
+```
+"""
+function constant(VecType::Type, v::Number)
+    VecType(ntuple(j->v, length(VecType)))
+end

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -27,7 +27,7 @@ const Vec2f = Vec{2,Float32}
 const Vec3f = Vec{3,Float32}
 
 """
-    euclidbasis(VecType, i)
+    vunit(VecType, i)
 
 Return the `i`-th vector in the Euclidean basis
 as a vector with type `VecType`.
@@ -35,19 +35,19 @@ as a vector with type `VecType`.
 ## Example
 
 ```julia
-euclidbasis(Vec3, 1) == [1.0, 0.0, 0.0]
-euclidbasis(Vec3, 2) == [0.0, 1.0, 0.0]
-euclidbasis(Vec3, 3) == [0.0, 0.0, 1.0]
+vunit(Vec3, 1) == [1.0, 0.0, 0.0]
+vunit(Vec3, 2) == [0.0, 1.0, 0.0]
+vunit(Vec3, 3) == [0.0, 0.0, 1.0]
 ```
 """
-function euclidbasis(VecType::Type, i::Integer)
+function vunit(VecType::Type, i::Integer)
     N = length(VecType)
     T = eltype(VecType)
     VecType(ntuple(j->ifelse(i==j, one(T), zero(T)), N))
 end
 
 """
-    constant(VecType, v)
+    vfill(VecType, v)
 
 Return the vector of type `VecType` with all
 coordinates equal to `v`.
@@ -55,10 +55,10 @@ coordinates equal to `v`.
 ## Example
 
 ```julia
-constant(Vec2, 3) == [3.0, 3.0]
-constant(Vec2f, 0) == [0.0f0, 0.0f0]
+vfill(Vec2, 3) == [3.0, 3.0]
+vfill(Vec2f, 0) == [0.0f0, 0.0f0]
 ```
 """
-function constant(VecType::Type, v::Number)
+function vfill(VecType::Type, v::Number)
     VecType(ntuple(j->v, length(VecType)))
 end

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -1,7 +1,7 @@
 using Test, GeometryBasics
 
 @testset "algorithms.jl" begin
-    cube = Rect(Vec3f0(-0.5,-0.5,-0.5), Vec3f0(1,1,1))
+    cube = FRect(Vec(-0.5,-0.5,-0.5), Vec(1,1,1))
     cube_faces = decompose(TriangleFace{Int}, faces(cube))
     cube_vertices = decompose(Point{3,Float32}, cube)
     @test area(cube_vertices, cube_faces) == 6
@@ -132,15 +132,15 @@ NFace = NgonFace
 end
 
 @testset "Normals" begin
-    n64 = Vec{3,Float64}[(0.0, 0.0, -1.0), (0.0, 0.0, -1.0), (0.0, 0.0, -1.0),
-                         (0.0, 0.0, -1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0),
-                         (0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (-1.0, 0.0, 0.0),
-                         (-1.0, 0.0, 0.0), (-1.0, 0.0, 0.0), (-1.0, 0.0, 0.0),
-                         (1.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 0.0, 0.0),
-                         (0.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 1.0, 0.0),
-                         (0.0, -1.0, 0.0), (0.0, -1.0, 0.0), (0.0, -1.0, 0.0),
-                         (0.0, -1.0, 0.0),]
-    n32 = map(Vec{3,Float32}, n64)
+    n64 = Vec3[(0.0, 0.0, -1.0), (0.0, 0.0, -1.0), (0.0, 0.0, -1.0),
+               (0.0, 0.0, -1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0),
+               (0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (-1.0, 0.0, 0.0),
+               (-1.0, 0.0, 0.0), (-1.0, 0.0, 0.0), (-1.0, 0.0, 0.0),
+               (1.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 0.0, 0.0),
+               (0.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 1.0, 0.0),
+               (0.0, -1.0, 0.0), (0.0, -1.0, 0.0), (0.0, -1.0, 0.0),
+               (0.0, -1.0, 0.0),]
+    n32 = map(Vec3f, n64)
     r = triangle_mesh(centered(Rect3D))
     # @test normals(coordinates(r), GeometryBasics.faces(r)) == n32
     # @test normals(coordinates(r), GeometryBasics.faces(r)) == n64
@@ -178,8 +178,8 @@ end
     @test (rect - 4) == FRect2D(-4, 3, 20, 3)
     @test (rect - Vec(2, -2)) == FRect2D(-2, 9, 20, 3)
 
-    base = Vec3f0(1, 2, 3)
-    wxyz = Vec3f0(-2, 4, 2)
+    base = Vec3f(1, 2, 3)
+    wxyz = Vec3f(-2, 4, 2)
     rect = FRect3D(base, wxyz)
     @test (rect + 4) == FRect3D(base .+ 4, wxyz)
     @test (rect + Vec(2, -2, 3)) == FRect3D(base .+ Vec(2, -2, 3), wxyz)
@@ -191,8 +191,8 @@ end
     @test (rect * 4) == FRect2D(0, 7 * 4, 20 * 4, 3 * 4)
     @test (rect * Vec(2, -2)) == FRect2D(0, -7 * 2, 20 * 2, -3 * 2)
 
-    base = Vec3f0(1, 2, 3)
-    wxyz = Vec3f0(-2, 4, 2)
+    base = Vec3f(1, 2, 3)
+    wxyz = Vec3f(-2, 4, 2)
     rect = FRect3D(base, wxyz)
     @test (rect * 4) == FRect3D(base .* 4, wxyz .* 4)
     @test (rect * Vec(2, -2, 3)) == FRect3D(base .* Vec(2, -2, 3), wxyz .* Vec(2, -2, 3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using GeometryBasics: attributes
         @testset "per vertex attributes" begin
             points = rand(Point{3, Float64}, 8)
             tfaces = TetrahedronFace{Int}[(1, 2, 3, 4), (5, 6, 7, 8)]
-            normals = rand(SVector{3, Float64}, 8)
+            normals = rand(Vec3, 8)
             stress = LinRange(0, 1, 8)
             mesh = Mesh(meta(points, normals = normals, stress = stress), tfaces)
 
@@ -215,7 +215,7 @@ end
         @testset "per vertex attributes" begin
             points = rand(Point{3, Float64}, 8)
             tfaces = TetrahedronFace{Int}[(1, 2, 3, 4), (5, 6, 7, 8)]
-            normals = rand(SVector{3, Float64}, 8)
+            normals = rand(Vec3, 8)
             stress = LinRange(0, 1, 8)
             mesh_nometa = Mesh(points, tfaces)
             mesh = MetaT(mesh_nometa, normals = normals, stress = stress)
@@ -374,8 +374,8 @@ end
 
         points = rand(Point3f0, 8)
         tfaces = [GLTriangleFace(1, 2, 3), GLTriangleFace(5, 6, 7)]
-        normals = rand(Vec3f0, 8)
-        uv = rand(Vec2f0, 8)
+        normals = rand(Vec3f, 8)
+        uv = rand(Vec2f, 8)
         mesh = Mesh(points, tfaces)
         meshuv = Mesh(meta(points; uv=uv), tfaces)
         meshuvnormal = Mesh(meta(points; normals=normals, uv=uv), tfaces)
@@ -442,13 +442,13 @@ end
 
     primitive = Sphere(Point3f0(0), 1)
     m_normal = normal_mesh(primitive)
-    @test normals(m_normal) isa Vector{Vec3f0}
+    @test normals(m_normal) isa Vector{Vec3f}
     primitive = Rect2D(0, 0, 1, 1)
     m_normal = normal_mesh(primitive)
-    @test normals(m_normal) isa Vector{Vec3f0}
+    @test normals(m_normal) isa Vector{Vec3f}
     primitive = Rect3D(0, 0, 0, 1, 1, 1)
     m_normal = normal_mesh(primitive)
-    @test normals(m_normal) isa Vector{Vec3f0}
+    @test normals(m_normal) isa Vector{Vec3f}
 
     points = decompose(Point2f0, Circle(Point2f0(0), 1))
     tmesh = triangle_mesh(points)
@@ -457,7 +457,7 @@ end
     m = GeometryBasics.mesh(Sphere(Point3f0(0), 1))
     @test normals(m) == nothing
     m_normals = pointmeta(m, Normal())
-    @test normals(m_normals) isa Vector{Vec3f0}
+    @test normals(m_normals) isa Vector{Vec3f}
 
     @test texturecoordinates(m) == nothing
     r2 = Rect2D(0.0, 0.0, 1.0, 1.0)
@@ -496,7 +496,7 @@ end
 end
 
 @testset "convert mesh + meta" begin
-    m = uv_normal_mesh(FRect3D(Vec3f0(-1,-1,-1), Vec3f0(1, 2, 3)))
+    m = uv_normal_mesh(FRect3D(Vec(-1,-1,-1), Vec(1, 2, 3)))
     m_normal = normal_mesh(m)
     # make sure we don't loose the uv
     @test hasproperty(m_normal, :uv)
@@ -506,8 +506,8 @@ end
     @test m.normals === m_normal.normals
     @test m.uv === m_normal.uv
 
-    m = GeometryBasics.mesh(FRect3D(Vec3f0(-1,-1,-1), Vec3f0(1, 2, 3));
-                            uv=Vec2{Float64}, normaltype=Vec3{Float64}, pointtype=Point3{Float64})
+    m = GeometryBasics.mesh(FRect3D(Vec(-1,-1,-1), Vec(1, 2, 3));
+                            uv=Vec2, normaltype=Vec3, pointtype=Point3{Float64})
     m_normal = normal_mesh(m)
     @test hasproperty(m_normal, :uv)
     @test m.position !== m_normal.position
@@ -546,7 +546,7 @@ end
         @test meta(x, value=[1]).position === x
     end
     pos = Point2f0[(10, 2)]
-    m = Mesh(meta(pos, uv=[Vec2f0(1, 1)]), [GLTriangleFace(1, 1, 1)])
+    m = Mesh(meta(pos, uv=[Vec2f(1, 1)]), [GLTriangleFace(1, 1, 1)])
     @test m.position === pos
 end
 


### PR DESCRIPTION
This is a continuation of #93 . It supersedes #97. Addresses #91.

Now we have a single type for representing vectors in geometrical spaces, and it happens to be an alias for `SVector` (implementation detail). Additionally, we have type aliases for end users that often wish to materialize vectors with specific coordinate type and dimension. Here, we avoid partial instantiation. The aliases `Vec2` and `Vec3` are concrete vector types in 2D and 3D using double precision, and the aliases `Vec2f` and `Vec3f` are concrete vector types using single precision.

We deprecate `unit` in favor of `euclidbasis`, which is a more accurate name for the returned vectors. We add `constant` as a helper function to construct vectors with repeated coordinates. The name `constant` isn't ideal, please let me know if you have a better suggestion.