### PR TITLE
bump compat for StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 IterTools = "1.3.0"
-StaticArrays = "0.12"
+StaticArrays = "0.12, 1.0"
 StructArrays = "0.3,0.4"
 Tables = "0.2, 1"
 julia = "1.3"


### PR DESCRIPTION
There was a new release of StaticArrays.jl and this packages holds back updates of some other packages downstream. I've made a PR adding CompatHelper to automate this process in the future, cf. #112.
It would be very nice to have a new release after merging this.