### PR TITLE
Add isempty

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeometryBasics"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 authors = ["SimonDanisch <sdanisch@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 EarCut_jll = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"

--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -309,6 +309,13 @@ end
 # set operations
 
 """
+    isempty(h::Rect)
+
+Return `true` if any of the widths of `h` are negative.
+"""
+Base.isempty(h::Rect{N,T}) where {N,T} = any(<(zero(T)), h.widths)
+
+"""
 Perform a union between two Rects.
 """
 function Base.union(h1::Rect{N}, h2::Rect{N}) where {N}

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -105,6 +105,8 @@ end
                              [2, 2, 2], [2, 2, 1], [1, 2, 1], [1, 2, 2]]
     @test decompose(Point{3,Int}, b) == pt_expb
     mesh = normal_mesh(b)
+
+    @test isempty(Rect{3,Float32}())
 end
 
 NFace = NgonFace


### PR DESCRIPTION
This will be used to avoid boxing (in the sense of `Core.Box`, a.k.a. julia#15276) in https://github.com/JuliaPlots/AbstractPlotting.jl/blob/6346fe87f18bb1df09f0065f0ad6b2b699c20b94/src/layouting/boundingbox.jl#L170-L199. I took the liberty of bumping the version to encourage a new release.