### PR TITLE
Fix mesh(::AbstractPolygon) in case faces returns nothing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -489,6 +489,12 @@ end
     @test decompose(Point{2, Int}, poly_ext_int) == [pts_ext..., pts_int1..., pts_int2...]
 end
 
+@testset "mesh" begin
+    primitive = Triangle(Point2f0(0), Point2f0(1), Point2f0(1,0))
+    m = GeometryBasics.mesh(primitive)
+    @test length(faces(m)) == 1
+end
+
 @testset "convert mesh + meta" begin
     m = uv_normal_mesh(Circle(Point2f0(0), 1f0))
     # for 2D primitives we dont actually calculate normals


### PR DESCRIPTION
When `faces` returns `nothing`, `mesh(::Meshable)` falls back on `decompose(facetype, positions)`. The fallback is missing from `mesh(::AbstractPolygon)` so the following fails:

```
julia> t = Triangle(Point2f0(0), Point2f0(1), Point2f0(1,0))
Triangle(Float32[0.0, 0.0], Float32[1.0, 1.0], Float32[1.0, 0.0])

julia> GeometryBasics.mesh(t)
ERROR: MethodError: no method matching Mesh(::Array{Point{2,Float32},1}, ::Nothing)
```

This PR adds the fallback to the `AbstractPolygon` case.