### PR TITLE
area and MetaFree fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.3'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,9 @@ Tables = "0.2, 1"
 julia = "1.3"
 
 [extras]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "OffsetArrays"]

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -102,7 +102,7 @@ macro meta_type(name, mainfield, supertype, params...)
             return $MetaName{$(params_sym...),ST,Names,Types}
         end
 
-        GeometryBasics.MetaFree(::Type{<:$MetaName{Typ}}) where {Typ} = Typ
+        GeometryBasics.MetaFree(::Type{<:$MetaName{$(params_sym...),Typ}}) where {$(params_sym...), Typ<:$supertype{$(params_sym...)} } = Typ
         GeometryBasics.MetaFree(::Type{<:$MetaName}) = $name
         GeometryBasics.metafree(x::$MetaName) = getfield(x, :main)
         GeometryBasics.metafree(x::AbstractVector{<:$MetaName}) = getproperty(x, $field)

--- a/src/triangulation.jl
+++ b/src/triangulation.jl
@@ -33,23 +33,28 @@ function area(vertices::AbstractVector{<:AbstractPoint{3,VT}},
     return sum(x -> area(vertices, x), faces)
 end
 
-function area(contour::AbstractVector{<:AbstractPoint{N,T}}) where {N,T}
-    n = length(contour)
-    n < 3 && return zero(T)
+"""
+    area(contour::AbstractVector{AbstractPoint}})
+
+Calculate the area of a polygon.
+
+For 2D points, the oriented area is returned (negative when the points are
+oriented clockwise).
+"""
+function area(contour::AbstractVector{<:AbstractPoint{2,T}}) where {T}
+    length(contour) < 3 && return zero(T)
     A = zero(T)
     p = lastindex(contour)
-    q = firstindex(contour)
-    while q <= n
+    for q in eachindex(contour)
         A += cross(contour[p], contour[q])
         p = q
-        q += 1
     end
     return A * T(0.5)
 end
 
-function area(contour::AbstractVector{Point{3,T}}) where {T}
+function area(contour::AbstractVector{<:AbstractPoint{3,T}}) where {T}
     A = zero(eltype(contour))
-    o = contour[1]
+    o = first(contour)
     for i in (firstindex(contour) + 1):(lastindex(contour) - 1)
         A += cross(contour[i] - o, contour[i + 1] - o)
     end
@@ -59,8 +64,7 @@ end
 """
     in(point, triangle)
 
- InsideTriangle decides if a point P is Inside of the triangle
- defined by A, B, C.
+Determine if a point is inside of a triangle.
 """
 function Base.in(P::T, triangle::Triangle) where {T<:AbstractPoint}
     A, B, C = coordinates(triangle)

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -1,14 +1,5 @@
 using Test, GeometryBasics
 
-@testset "algorithms.jl" begin
-    cube = Rect(Vec3f0(-0.5), Vec3f0(1))
-    cube_faces = decompose(TriangleFace{Int}, faces(cube))
-    cube_vertices = decompose(Point{3,Float32}, cube)
-    @test area(cube_vertices, cube_faces) == 6
-    mesh = Mesh(cube_vertices, cube_faces)
-    @test GeometryBasics.volume(mesh) ≈ 1
-end
-
 @testset "Cylinder" begin
     @testset "constructors" begin
         o, extr, r = Point2f0(1, 2), Point2f0(3, 4), 5.0f0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,9 @@ using GeometryBasics: attributes
 
     points3d = Point3f0[(0,0,0), (0,0,1), (0,1,1)]
     @test area(OffsetArray(points3d, -2)) ≈ 0.5
+
+    pm2d = [PointMeta(0.0, 0.0, a=:d), PointMeta(0.0, 1.0, a=:e), PointMeta(1.0, 0.0, a=:f)]
+    @test area(pm2d) ≈ -0.5
 end
 
 @testset "embedding metadata" begin
@@ -102,13 +105,14 @@ end
     @testset "point with metadata" begin
         p = Point(1.1, 2.2)
         @test p isa AbstractVector{Float64}
-        pm = GeometryBasics.PointMeta(1.1, 2.2; a=1, b=2)
+        pm = PointMeta(1.1, 2.2; a=1, b=2)
         p1 = Point(2.2, 3.6)
         p2 = [p, p1]
         @test coordinates(p2) == p2
         @test meta(pm) === (a=1, b=2)
         @test metafree(pm) === p
         @test propertynames(pm) == (:position, :a, :b)
+        @test GeometryBasics.MetaFree(typeof(pm)) == Point{2,Float64}
     end
 
     @testset "MultiPoint with metadata" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,27 @@
-using Test, Random, StructArrays, Tables, StaticArrays
+using Test, Random, StructArrays, Tables, StaticArrays, OffsetArrays
 using GeometryBasics
 using LinearAlgebra
 using GeometryBasics: attributes
 
 @testset "GeometryBasics" begin
+
+@testset "algorithms" begin
+    cube = Rect(Vec3f0(-0.5), Vec3f0(1))
+    cube_faces = decompose(TriangleFace{Int}, faces(cube))
+    cube_vertices = decompose(Point{3,Float32}, cube)
+    @test area(cube_vertices, cube_faces) == 6
+    mesh = Mesh(cube_vertices, cube_faces)
+    @test GeometryBasics.volume(mesh) ≈ 1
+
+    points_cwise = Point2f0[(0,0), (0,1), (1,1)]
+    points_ccwise = Point2f0[(0,0), (1,0), (1,1)]
+    @test area(points_cwise) ≈ -0.5
+    @test area(points_ccwise) ≈ 0.5
+    @test area(OffsetArray(points_cwise, -2)) ≈ -0.5
+
+    points3d = Point3f0[(0,0,0), (0,0,1), (0,1,1)]
+    @test area(OffsetArray(points3d, -2)) ≈ 0.5
+end
 
 @testset "embedding metadata" begin
     @testset "Meshes" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,9 @@ using GeometryBasics: attributes
 
     pm2d = [PointMeta(0.0, 0.0, a=:d), PointMeta(0.0, 1.0, a=:e), PointMeta(1.0, 0.0, a=:f)]
     @test area(pm2d) ≈ -0.5
+
+    pm3d = [PointMeta(0.0, 0.0, 0.0, a=:d), PointMeta(0.0, 1.0, 0.0, a=:e), PointMeta(1.0, 0.0, 0.0, a=:f)]
+    @test_broken area(pm3d) ≈ 0.5 # Currently broken as zero(PointMeta(0.0, 0.0, 0.0, a=:d)) fails
 end
 
 @testset "embedding metadata" begin
@@ -113,6 +116,7 @@ end
         @test metafree(pm) === p
         @test propertynames(pm) == (:position, :a, :b)
         @test GeometryBasics.MetaFree(typeof(pm)) == Point{2,Float64}
+        @test_broken zero(pm) == [0, 0]
     end
 
     @testset "MultiPoint with metadata" begin


### PR DESCRIPTION
Some fixes for `area` following discussion in #121

* `area(::AbstractVector{AbstractPoint}})` is now documented
* In particular, the doc says that a signed value is returned in the 2D case
* Fixes for custom indices (OffsetArrays is added as a test dependency)
* The 3D case now accepts vectors of any `AbstractPoint{3}` type (the 2D case already did)

There's also a broken `area` test for a vector of `PointMeta{3}`. I couldn't make it work because it needs `zero(typeof(PointMeta(0,0,0; a=1))` and it's not clear how to implement that: How should we make the zero value of the metadata?

The PR includes a fix for a related bug: `MetaFree(typeof(PointMeta(0,0,0; a=1))` used to return `3`. Now it returns `Point{3,Int64}`, I think that's what was intended? (the fix isn't enough to make `area` work but I included it in the PR since it took me a while to figure out).

I also added Julia 1.3 in the CI test matrix, to avoid a repeat of #123 😊
