### PR TITLE
Export `HyperRectangle`

### DIFF
--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -61,7 +61,7 @@ export uv_mesh, normal_mesh, uv_normal_mesh
 export height, origin, radius, width, widths, xwidth, yheight
 export HyperSphere, Circle, Sphere
 export Cylinder, Cylinder2, Cylinder3, Pyramid, extremity
-export Rect, Rect2D, Rect3D, IRect, IRect2D, IRect3D, FRect, FRect2D, FRect3D
+export HyperRectangle, Rect, Rect2D, Rect3D, IRect, IRect2D, IRect3D, FRect, FRect2D, FRect3D
 export before, during, isinside, isoutside, meets, overlaps, intersects, finishes
 export centered, direction, area, update
 export max_dist_dim, max_euclidean, max_euclideansq, min_dist_dim, min_euclidean


### PR DESCRIPTION
Not sure why it's not being exported but I found it useful on its own so thought it might be good to export.