### PR TITLE
fuller StructArrays integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 IterTools = "1.3.0"
 StaticArrays = "0.12, 1.0"
-StructArrays = "0.3,0.4, 0.5"
+StructArrays = "0.5"
 Tables = "0.2, 1"
 julia = "1.3"
 

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -158,6 +158,11 @@ macro meta_type(name, mainfield, supertype, params...)
             return ($field, Names...)
         end
 
+        function StructArrays.component(x::$MetaName{$(params_sym...),Typ,Names,Types},
+                                        field::Symbol) where {$(params...),Typ,Names,Types}
+            return getproperty(x, field)
+        end
+
         function StructArrays.staticschema(::Type{$MetaName{$(params_sym...),Typ,Names,
                                                             Types}}) where {$(params...),
                                                                             Typ,Names,Types}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -684,6 +684,29 @@ end
     @test Base.size(feat[1]) == (2,)
 end
 
+@testset "StructArrays integration" begin
+    pt = meta(Point(0.0, 0.0), color="red", alpha=0.1)
+    @test StructArrays.component(pt, :position) == Point(0.0, 0.0)
+    @test StructArrays.component(pt, :color) == "red"
+    @test StructArrays.component(pt, :alpha) == 0.1
+    @test StructArrays.staticschema(typeof(pt)) ==
+        NamedTuple{(:position, :color, :alpha), Tuple{Point2{Float64}, String, Float64}}
+    @test StructArrays.createinstance(typeof(pt), Point(0.0, 0.0), "red", 0.1) == pt
+
+    s = StructArray([pt, pt])
+    @test StructArrays.components(s) == (
+        position = [Point(0.0, 0.0), Point(0.0, 0.0)],
+        color = ["red", "red"],
+        alpha = [0.1, 0.1]
+    )
+    s[2] = meta(Point(0.1, 0.1), color="blue", alpha=0.3)
+    @test StructArrays.components(s) == (
+        position = [Point(0.0, 0.0), Point(0.1, 0.1)],
+        color = ["red", "blue"],
+        alpha = [0.1, 0.3]
+    )
+end
+
 @testset "Tests from GeometryTypes" begin
     include("geometrytypes.jl")
 end


### PR DESCRIPTION
In StructArrays 0.5, the interface has been slightly modified (see [NEWS entry](https://github.com/JuliaArrays/StructArrays.jl/blob/master/NEWS.md#version-050)), so now it is necessary to overload `component` as well for stucts with custom layout.

This allows better StructArrays integration and makes things like `setindex!` work out of the box with `StructArray`s of meta geometries.

I've also added tests to make sure the full interface is implemented.