### PR TITLE
fix (generated) normals of Pyramid

### DIFF
--- a/src/primitives/pyramids.jl
+++ b/src/primitives/pyramids.jl
@@ -12,8 +12,14 @@ function coordinates(p::Pyramid{T}) where {T}
     ld = Point{3,T}(p.middle + leftdown)
     ru = Point{3,T}(p.middle - leftdown)
     rd = Point{3,T}(p.middle - leftup)
-    return Point{3,T}[tip, rd, ru, tip, ru, lu, tip, lu, ld, tip, ld, rd, rd, ru, lu, lu,
-                      ld, rd]
+    return Point{3,T}[
+        tip, rd, ru, 
+        tip, ru, lu, 
+        tip, lu, ld, 
+        tip, ld, rd, 
+        ru, rd, lu, 
+        ld, lu, rd
+    ]
 end
 
 function faces(::Pyramid)


### PR DESCRIPTION
Fixes the directions of normals of the bottom faces of a `Pyramid`. Since it's kinda hard to see - the change here is swapping `ru, rd` and `ld, lu` so that the winding directions is correct.

Mentioned in #139 