### PR TITLE
update Base.in for HyperSphere

### DIFF
--- a/src/primitives/spheres.jl
+++ b/src/primitives/spheres.jl
@@ -31,11 +31,8 @@ origin(c::HyperSphere) = c.center
 Base.minimum(c::HyperSphere{N,T}) where {N,T} = Vec{N,T}(origin(c)) - Vec{N,T}(radius(c))
 Base.maximum(c::HyperSphere{N,T}) where {N,T} = Vec{N,T}(origin(c)) + Vec{N,T}(radius(c))
 
-function Base.in(x::AbstractPoint{2}, c::Circle)
-    @inbounds ox, oy = origin(c)
-    xD = abs(ox - x)
-    yD = abs(oy - y)
-    return xD <= c.r && yD <= c.r
+function Base.in(x::AbstractPoint, c::HyperSphere)
+    return norm(origin(c) - x) ≤ radius(c)
 end
 
 centered(S::Type{HyperSphere{N,T}}) where {N,T} = S(Vec{N,T}(0), T(0.5))


### PR DESCRIPTION
This PR fixes #108.

# Before this PR
```julia
julia> using GeometryBasics

julia> C = Circle(Point(1,1),1)
Circle{Int64}([1, 1], 1)

julia> Point(0,0) in C
ERROR: MethodError: no method matching -(::Int64, ::Point2{Int64})
For element-wise subtraction, use broadcasting with dot syntax: scalar .- array
Closest candidates are:
  -(::Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}) at int.jl:85
  -(::T, ::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8} at int.jl:86
  -(::Union{Int16, Int32, Int64, Int8}, ::BigInt) at gmp.jl:536
  ...
Stacktrace:
 [1] in(x::Point2{Int64}, c::Circle{Int64})
   @ GeometryBasics ~/.julia/dev/GeometryBasics/src/primitives/spheres.jl:36
 [2] top-level scope
   @ REPL[3]:1

julia> S = Sphere(Point(1,1,1),10)
Sphere{Int64}([1, 1, 1], 10)

julia> Point(1,1,1) in S
ERROR: MethodError: no method matching iterate(::Sphere{Int64})
Closest candidates are:
  iterate(::Union{LinRange, StepRangeLen}) at range.jl:664
  iterate(::Union{LinRange, StepRangeLen}, ::Int64) at range.jl:664
  iterate(::T) where T<:Union{Base.KeySet{var"#s79", var"#s78"} where {var"#s79", var"#s78"<:Dict}, Base.ValueIterator{var"#s77"} where var"#s77"<:Dict} at dict.jl:693
  ...
Stacktrace:
 [1] in(x::Point3{Int64}, itr::Sphere{Int64})
   @ Base ./operators.jl:1131
 [2] top-level scope
   @ REPL[5]:1
```


# After this PR
```julia
julia> using GeometryBasics

julia> C = Circle(Point(1,1),1)
Circle{Int64}([1, 1], 1)

julia> Point(1,1) in C
true

julia> Point(0,0) in C
false

julia> S = Sphere(Point(1,1,1),10)
Sphere{Int64}([1, 1, 1], 10)

julia> Point(1,1,1) in S
true
```