### PR TITLE
update structarrays compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    env:
+      JULIA_PKG_SERVER: ""
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -52,7 +54,6 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Pkg
-            Pkg.update()
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Pkg
+            Pkg.update()
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
       - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 IterTools = "1.3.0"
 StaticArrays = "0.12, 1.0"
-StructArrays = "0.5"
+StructArrays = "0.6"
 Tables = "0.2, 1"
 julia = "1.3"
 

--- a/src/viewtypes.jl
+++ b/src/viewtypes.jl
@@ -96,7 +96,7 @@ end
         columns = ntuple(N) do i
             return view(points, ((i - 1) * seglen + 1):(i * seglen))
         end
-        return StructArray{Point{N,T}}((StructArray{NTuple{N,T}}(columns),))
+        return StructArray{Point{N,T}}(columns)
     else
         error("Dim 1 or 2 must be equal to the point dimension!")
     end


### PR DESCRIPTION
In StructArrays 0.6, StaticArrays are treated the same way as the underlying `Tuple` in terms of data storage, so one should pass the tuple of columns directly to the constructor, without having to nest `StructArray`s.

I'm dropping compatibility with the older version, because it seems tricky to support both.