### PR TITLE
fix Rect3 uv coordinates

### DIFF
--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -553,7 +553,17 @@ function coordinates(rect::Rect3)
 end
 
 function texturecoordinates(rect::Rect3)
-    return coordinates(Rect3(0, 0, 0, 1, 1, 1))
+    # compatible with a texture ordered:
+    # [+x +y +z; -x -y -z]
+    uvs = map(v -> v ./ (3, 2), Vec{2, Float32}[
+        (2, 0), (2, 1), (3, 1), (3, 0),
+        (1, 0), (1, 1), (2, 1), (2, 0),
+        (0, 0), (0, 1), (1, 1), (1, 0),
+        (2, 1), (2, 2), (3, 2), (3, 1),
+        (0, 1), (0, 2), (1, 2), (1, 1),
+        (1, 1), (1, 2), (2, 2), (2, 1),
+    ])
+    return uvs
 end
 
 function faces(rect::Rect3)


### PR DESCRIPTION
The current uv's in Rect3 are just the xy components of the coordinates. That means uvs are doubly assigned and not normalized. This pr adds some manual uvs so that
```julia
img = [
    RGBf(1,0,0) RGBf(0,1,0) RGBf(0,0,1);
    RGBf(0,1,1) RGBf(1,0,1) RGBf(1,1,0);
]
```
colors a cube. (Colors applying to the `[+x, +y, +z; -x, -y, -z]` face.)