### PR TITLE
Pass input types to mesh

### DIFF
--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -167,36 +167,36 @@ function mesh(polygon::AbstractPolygon{Dim,T}; pointtype=Point{Dim,T},
     return Mesh(positions, faces)
 end
 
-function triangle_mesh(primitive::Meshable{N}; nvertices=nothing) where {N}
+function triangle_mesh(primitive::Meshable{N,T}; nvertices=nothing) where {N,T}
     if nvertices !== nothing
         @warn("nvertices argument deprecated. Wrap primitive in `Tesselation(primitive, nvertices)`")
         primitive = Tesselation(primitive, nvertices)
     end
-    return mesh(primitive; pointtype=Point{N,Float32}, facetype=GLTriangleFace)
+    return mesh(primitive; pointtype=Point{N,T}, facetype=GLTriangleFace)
 end
 
 function uv_mesh(primitive::Meshable{N,T}) where {N,T}
-    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f, facetype=GLTriangleFace)
+    return mesh(primitive; pointtype=Point{N,T}, uv=Vec{2,T}, facetype=GLTriangleFace)
 end
 
-function uv_normal_mesh(primitive::Meshable{N}) where {N}
-    return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f, normaltype=Vec3f,
+function uv_normal_mesh(primitive::Meshable{N,T}) where {N,T}
+    return mesh(primitive; pointtype=Point{N,T}, uv=Vec{2,T}, normaltype=Vec{3,T},
                 facetype=GLTriangleFace)
 end
 
-function normal_mesh(points::AbstractVector{<:AbstractPoint},
-                     faces::AbstractVector{<:AbstractFace})
-    _points = decompose(Point3f, points)
+function normal_mesh(points::AbstractVector{<:AbstractPoint{N,T}},
+                     faces::AbstractVector{<:AbstractFace}) where {N,T}
+    _points = decompose(Point{N,T}, points)
     _faces = decompose(GLTriangleFace, faces)
     return Mesh(meta(_points; normals=normals(_points, _faces)), _faces)
 end
 
-function normal_mesh(primitive::Meshable{N}; nvertices=nothing) where {N}
+function normal_mesh(primitive::Meshable{N,T}; nvertices=nothing) where {N,T}
     if nvertices !== nothing
         @warn("nvertices argument deprecated. Wrap primitive in `Tesselation(primitive, nvertices)`")
         primitive = Tesselation(primitive, nvertices)
     end
-    return mesh(primitive; pointtype=Point{N,Float32}, normaltype=Vec3f,
+    return mesh(primitive; pointtype=Point{N,T}, normaltype=Vec{3,T},
                 facetype=GLTriangleFace)
 end
 


### PR DESCRIPTION
For https://github.com/MakieOrg/Makie.jl/pull/2573

Adjusts mesh generating functions to keep the input element type around, rather than converting to Float32