### PR TITLE
More GeoInterface methods

### DIFF
--- a/src/boundingboxes.jl
+++ b/src/boundingboxes.jl
@@ -1,7 +1,4 @@
-function Rect(geometry::AbstractArray{<:Point{N,T}}) where {N,T}
-    return Rect{N,T}(geometry)
-end
-
+# the basic method
 """
 Construct a HyperRectangle enclosing all points.
 """
@@ -23,6 +20,30 @@ function Rect{N1,T1}(geometry::AbstractArray{PT}) where {N1,T1,PT<:AbstractPoint
     end
 end
 
+function Rect(geometry::AbstractArray{<:Point{N,T}}) where {N, T}
+    return Rect{N,T}(geometry)
+end
+
+function Rect{T1}(geometry::AbstractArray{<:Point{N,T2}}) where {N, T1, T2}
+    return Rect{N,T1}(geometry)
+end
+
+Rect(a::AbstractGeometry{N, T}) where {N, T} = Rect{N, T}(a)
+Rect{T1}(a::AbstractGeometry{N, T2}) where {N, T1, T2} = Rect{N, T1}(a)
+function Rect{N1, T1}(a::AbstractGeometry{N2, T2}) where {N1, T1, N2, T2}
+    return Rect{N1, T1}(coordinates(a))
+end
+
+Rect(a::AbstractArray{<: AbstractGeometry{N, T}}) where {N, T} = Rect{N, T}(a)
+Rect{T1}(a::AbstractArray{<: AbstractGeometry{N, T2}}) where {N, T1, T2} = Rect{N, T1}(a)
+function Rect{N1, T1}(a::AbstractArray{<: AbstractGeometry{N2, T2}}) where {N1, T1, N2, T2}
+    return reduce(union, Rect{N1, T1}.(a))
+end
+
+# generic fallbacks and entry point
+Rect{T}(a) where {T} = Rect{T}(coordinates(a))
+Rect{N,T}(a) where {N,T} = Rect{N,T}(coordinates(a))
+
 function Rect(primitive::GeometryPrimitive{N,T}) where {N,T}
     return Rect{N,T}(primitive)
 end
@@ -31,16 +52,27 @@ function Rect{T}(primitive::GeometryPrimitive{N,T}) where {N,T}
     return Rect{N,T}(primitive)
 end
 
-function Rect{T}(a::Pyramid) where {T}
+# function Rect{N1, T1}(primitives::AbstractArray{<: GeometryPrimitive{N2, T2}})
+# end
+
+# specialized overloads for geometries with a known bbox
+
+function Rect{3, T}(a::Pyramid) where {T}
     w, h = a.width / T(2), a.length
     m = Vec{3,T}(a.middle)
-    return Rect{T}(m .- Vec{3,T}(w, w, 0), m .+ Vec{3,T}(w, w, h))
+    return Rect{3, T}(m .- Vec{3,T}(w, w, 0), m .+ Vec{3,T}(w, w, h))
 end
 
-function Rect{T}(a::Sphere) where {T}
+function Rect{2, T}(a::Sphere) where {T}
     mini, maxi = extrema(a)
     return Rect{T}(mini, maxi .- mini)
 end
 
-Rect{T}(a) where {T} = Rect{T}(coordinates(a))
-Rect{N,T}(a) where {N,T} = Rect{N,T}(coordinates(a))
+function Rect{N1, T}(hypersph::GeometryBasics.HyperSphere{N2}) where {T, N1, N2}
+    mini, maxi = extrema(hypersph)
+    if length(mini) < N1
+        mini = vcat(mini, zeros(N1 - length(mini)))
+        maxi = vcat(maxi, zeros(N1 - length(mini)))
+    end
+    return Rect{N1, T}(mini, maxi .- mini)
+end

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -296,17 +296,33 @@ function centroid(ls::LineString{2, T}) where T
     return centroid ./ total_area
 end
 
+# a more optimized function, so we only calculate signed area once!
+function centroid_and_signed_area(ls::LineString{2, T}) where T
+    centroid = Point{2, T}(0)
+    total_area = T(0)
+    if length(ls) == 1
+        return sum(ls[1])/2
+    end
+
+    p0 = ls[1][1]
+
+    for i in 1:(length(ls)-1)
+        p1 = ls[i][2]
+        p2 = ls[i+1][2]
+        area = signed_area(p0, p1, p2)
+        centroid = centroid .+ Point{2, T}((p0[1] + p1[1] + p2[1])/3, (p0[2] + p1[2] + p2[2])/3) * area
+        total_area += area
+    end
+    return (centroid ./ total_area, total_area)
+end
+
 function centroid(poly::GeometryBasics.Polygon{2, T}) where T
-    exterior_points = decompose(Point2f, poly.exterior)
-    exterior_centroid = centroid(poly.exterior)
-    exterior_area = signed_area(poly.exterior)
+    exterior_centroid, exterior_area = centroid_and_signed_area(poly.exterior)
 
     total_area = exterior_area
     interior_numerator = Point{2, T}(0)
     for interior in poly.interiors
-        interior_points = decompose(Point2f, interior)
-        interior_centroid = centroid(interior)
-        interior_area = signed_area(interior_points)
+        interior_centroid, interior_area = centroid_and_signed_area(interior)
         total_area += interior_area
         interior_numerator += interior_centroid * interior_area
     end
@@ -316,14 +332,11 @@ function centroid(poly::GeometryBasics.Polygon{2, T}) where T
 end
 
 function centroid(multipoly::MultiPolygon)
-
     centroids = centroid.(multipoly.polygons)
-
     areas = signed_area.(multipoly.polygons)
     areas ./= sum(areas)
 
     return sum(centroids .* areas) / sum(areas)
-
 end
 
 

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -24,6 +24,15 @@ GeoInterface.geomtrait(::Simplex{Dim,T,1}) where {Dim,T} = PointTrait()
 GeoInterface.geomtrait(::Simplex{Dim,T,2}) where {Dim,T} = LineStringTrait()
 GeoInterface.geomtrait(::Simplex{Dim,T,3}) where {Dim,T} = PolygonTrait()
 
+# GeoInterface calls this method in `GeoInterface.convert(GeometryBasics, ...)`
+geointerface_geomtype(::GeoInterface.PointTrait) = Point
+geointerface_geomtype(::GeoInterface.MultiPointTrait) = MultiPoint
+geointerface_geomtype(::GeoInterface.LineStringTrait) = LineString
+geointerface_geomtype(::GeoInterface.MultiLineStringTrait) = MultiLineString
+geointerface_geomtype(::GeoInterface.PolygonTrait) = Polygon
+geointerface_geomtype(::GeoInterface.MultiPolygonTrait) = MultiPolygon
+geointerface_geomtype(::GeoInterface.PolyhedralSurfaceTrait) = AbstractMesh
+
 GeoInterface.ncoord(::PointTrait, g::Point) = length(g)
 GeoInterface.getcoord(::PointTrait, g::Point, i::Int) = g[i]
 

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -360,7 +360,7 @@ function GeoInterface.contains(
     point::Point{2, T2}
     ) where {T1, T2} 
 
-    contains(ls, point)
+    contains(geom, point)
 
 end
 
@@ -368,55 +368,49 @@ end
 #            Implementation            #
 ########################################
 
-# test if point B is on the line defined by A and C
-function is_on_line(A::Point2, B::Point2, C::Point2)
-   # if AC is vertical
-   if (A[1] == C[1]) 
-        return B[1] == C[1]
-   # if AC is horizontal
-   elseif (A[2] == C[2]) 
-        return B[2] == C[2]
-   end
-   # match the gradients
-   return (A[1] - C[1])*(A[2] - C[2]) == (C[1] - B[1])*(C[2] - B[2])
-end
+_cross(p1, p2, p3) = (p1[1] - p3[1]) * (p2[2] - p3[2]) - (p2[1] - p3[1]) * (p1[2] - p3[2])
 
+# Implementation of a point-in-polygon algorithm
+# from Luxor.jl.  This is the Hormann-Agathos (2001) algorithm.
+# For the source, see https://github.com/JuliaGraphics/Luxor.jl/blob/66d60fb51f6b1bb38690fe8dcc6c0084eeb80710/src/polygons.jl#L190-L229.
 function contains(ls::GeometryBasics.LineString{2, T1}, point::Point{2, T2}) where {T1, T2}
-
-    # the original C code from https://wrfranklin.org/Research/Short_Notes/pnpoly.html
-    # int pnpoly(int npol, float *xp, float *yp, float x, float y)
-    # {
-    #   i = 1
-    #   j = 1
-    #   c = false
-    #   for (i = 0, j = npol-1; i < npol; j = i++) {
-    #     if ((((yp[i]<=y) && (y<yp[j])) ||
-    #          ((yp[j]<=y) && (y<yp[i]))) &&
-    #         (x < (xp[j] - xp[i]) * (y - yp[i]) / (yp[j] - yp[i]) + xp[i]))
-
-    #       c = !c;
-    #   }
-    #   return c;
-
-    # }
-    x, y = point
-
+    pointlist = decompose(Point{2, promote_type(T1, T2)}, ls)
     c = false
-    @inbounds for (p1, p2) in ls
-        # handle vertex and edge cases
-        if p1 == point || p2 == point
-            return true
-        elseif (p1[1] < x < p2[1] && p1[2] < y < p2[2]) || (p2[1] < x < p1[1] && p2[2] < y < p1[2]) # point is in bbox of line
-            return is_on_line(p1, point, p2)
+    @inbounds for counter in eachindex(pointlist)
+        q1 = pointlist[counter]
+        # if reached last point, set "next point" to first point
+        if counter == length(pointlist)
+            q2 = pointlist[1]
+        else
+            q2 = pointlist[counter + 1]
         end
-        # Hormann-Agathos ray casting method
-        if ((p1[2] ≤ y && y < p2[2]) ||
-            (p2[2] ≤ y && y < p1[2])) &&
-            (x < (p2[1] - p1[1]) * (y - p1[2]) / (p2[2] - p1[2]) + p1[1])
-            c = !c
+        if q1 == point
+            # allowonedge || error("isinside(): VertexException a")
+            continue
+        end
+        if q2[2] == point[2]
+            if q2[1] == point[1]
+                # allowonedge || error("isinside(): VertexException b")
+                continue
+            elseif (q1[2] == point[2]) && ((q2[1] > point[1]) == (q1[1] < point[1]))
+                # allowonedge || error("isinside(): EdgeException")
+                continue
+            end
+        end
+        if (q1[2] < point[2]) != (q2[2] < point[2]) # crossing
+            if q1[1] >= point[1]
+                if q2[1] > point[1]
+                    c = !c
+                elseif ((_cross(q1, q2, point) > 0) == (q2[2] > q1[2]))
+                    c = !c
+                end
+            elseif q2[1] > point[1]
+                if ((_cross(q1, q2, point) > 0) == (q2[2] > q1[2]))
+                    c = !c
+                end
+            end
         end
     end
-
     return c
 
 end
@@ -425,14 +419,13 @@ function contains(poly::Polygon{2, T1}, point::Point{2, T2}) where {T1, T2}
     c = contains(poly.exterior, point)
     for interior in poly.interiors
         if contains(interior, point)
-            c = false # if hole contains point, then point is not contained in poly.
-            break
+            return false
         end
     end
     return c
 end
 
-# TODOs: implement contains for mesh, 
+# TODOs: implement contains for mesh, simplex, and 3d objects (eg rect, triangle, etc.)
 
 contains(mp::MultiPolygon{2, T1}, point::Point{2, T2}) where {T1, T2} = any((contains(poly, point) for poly in mp.polygons))
 

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -125,6 +125,8 @@ function GeoInterface.convert(::Type{MultiPolygon}, type::MultiPolygonTrait, geo
     return MultiPolygon([GeoInterface.convert(Polygon, t, poly) for poly in getgeom(geom)])
 end
 
+GeoInterface.centroid(::Union{GeoInterface.MultiPolygonTrait, GeoInterface.PolygonTrait}, geom) = centroid(geom)
+
 
 # Implementations for and overloads of various GeoInterface optional functions
 


### PR DESCRIPTION
This PR adds the following features:
- [x] Add more methods for Rect construction, since that's basically used as our bbox type.  Calling `Rect` on any geometry should now return a `Rect` which is the bbox of that geometry.
- [x] Implement `GeoInterface.extent` on top of the previous Rect changes.
- [x] Implement `GeometryBasics.geointerface_geomtype`, which GeoInterface picks up to allow other packages' geometries to be easily converted to GeometryBasics geometries (TODO: should we use this behaviour in Makie somehow?)
- [x] Implement a lot of polygon operations like centroid, distance, signed area, etc.  Also define GeoInterface methods backing these.
- [x] Reformat and add small optimizations to src/geointerface.jl.

TODOs still remaining:

- [x] Add a method to find distance which works well everywhere (the current method only checks for distance to nearest vertex)
- [ ] Look through the whole package, find more methods which GeoInterface methods can call
- [ ] Add tests
- [x] Make sure that performance is good! (tested with Polylabel.jl, it was pretty fast).