### PR TITLE
vectors are not `isgeometry` material

### DIFF
--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -4,6 +4,12 @@ GeoInterface.isgeometry(::Type{<:AbstractGeometry}) = true
 GeoInterface.isgeometry(::Type{<:AbstractFace}) = true
 GeoInterface.isgeometry(::Type{<:AbstractPoint}) = true
 GeoInterface.isgeometry(::Type{<:AbstractMesh}) = true
+GeoInterface.isgeometry(::Type{<:AbstractLineString}) = true
+GeoInterface.isgeometry(::Type{<:AbstractPolygon}) = true
+GeoInterface.isgeometry(::Type{<:MultiPoint}) = true
+GeoInterface.isgeometry(::Type{<:MultiLineString}) = true
+GeoInterface.isgeometry(::Type{<:MultiPolygon}) = true
+GeoInterface.isgeometry(::Type{<:Mesh}) = true
 
 GeoInterface.geomtrait(::Point) = PointTrait()
 GeoInterface.geomtrait(::Line) = LineTrait()
@@ -18,6 +24,7 @@ GeoInterface.geomtrait(::AbstractMesh) = PolyhedralSurfaceTrait()
 # GeoInterface calls this method in `GeoInterface.convert(GeometryBasics, ...)`
 geointerface_geomtype(::GeoInterface.PointTrait) = Point
 geointerface_geomtype(::GeoInterface.MultiPointTrait) = MultiPoint
+geointerface_geomtype(::GeoInterface.LineTrait) = Line
 geointerface_geomtype(::GeoInterface.LineStringTrait) = LineString
 geointerface_geomtype(::GeoInterface.MultiLineStringTrait) = MultiLineString
 geointerface_geomtype(::GeoInterface.PolygonTrait) = Polygon

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -3,12 +3,7 @@
 GeoInterface.isgeometry(::Type{<:AbstractGeometry}) = true
 GeoInterface.isgeometry(::Type{<:AbstractFace}) = true
 GeoInterface.isgeometry(::Type{<:AbstractPoint}) = true
-GeoInterface.isgeometry(::Type{<:AbstractVector{<:AbstractGeometry}}) = true
-GeoInterface.isgeometry(::Type{<:AbstractVector{<:AbstractPoint}}) = true
-GeoInterface.isgeometry(::Type{<:AbstractVector{<:LineString}}) = true
-GeoInterface.isgeometry(::Type{<:AbstractVector{<:AbstractPolygon}}) = true
-GeoInterface.isgeometry(::Type{<:AbstractVector{<:AbstractFace}}) = true
-GeoInterface.isgeometry(::Type{<:Mesh}) = true
+GeoInterface.isgeometry(::Type{<:AbstractMesh}) = true
 
 GeoInterface.geomtrait(::Point) = PointTrait()
 GeoInterface.geomtrait(::Line) = LineTrait()

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -60,8 +60,7 @@ GeoInterface.getgeom(::MultiPointTrait, g::MultiPoint, i::Int) = g[i]
 function GeoInterface.ngeom(::MultiLineStringTrait, g::MultiLineString)
     return length(g)
 end
-function GeoInterface.getgeom(::MultiLineStringTrait, g::MultiLineString,
-                              i::Int)
+function GeoInterface.getgeom(::MultiLineStringTrait, g::MultiLineString, i::Int)
     return g[i]
 end
 GeoInterface.ncoord(::MultiLineStringTrait, g::MultiLineString{Dim}) where {Dim} = Dim
@@ -123,7 +122,7 @@ function GeoInterface.convert(::Type{Polygon}, type::PolygonTrait, geom)
     if GeoInterface.nhole(geom) == 0
         return Polygon(exterior)
     else
-        interiors = GeoInterface.convert.(LineString, Ref(t), GeoInterface.gethole(geom))
+        interiors = map(h -> GeoInterface.convert(LineString, t, h), GeoInterface.gethole(geom))
         return Polygon(exterior, interiors)
     end
 end
@@ -143,10 +142,10 @@ end
 
 function GeoInterface.convert(::Type{MultiLineString}, type::MultiLineStringTrait, geom)
     t = LineStringTrait()
-    return MultiLineString([GeoInterface.convert(LineString, t, l) for l in getgeom(geom)])
+    return MultiLineString(map(l -> GeoInterface.convert(LineString, t, l), getgeom(geom)))
 end
 
 function GeoInterface.convert(::Type{MultiPolygon}, type::MultiPolygonTrait, geom)
     t = PolygonTrait()
-    return MultiPolygon([GeoInterface.convert(Polygon, t, poly) for poly in getgeom(geom)])
+    return MultiPolygon(map(poly -> GeoInterface.convert(Polygon, t, poly), getgeom(geom)))
 end

--- a/test/geointerface.jl
+++ b/test/geointerface.jl
@@ -1,17 +1,27 @@
 @testset "Basic types" begin
     point = Point(2, 3)
+    @test geomtrait(point) isa PointTrait
     @test testgeometry(point)
     @test ncoord(point) == 2
     @test getcoord(point, 2) == 3
     @test GeoInterface.coordinates(point) == [2, 3]
 
+    line = Line(Point(2, 3), Point(4, 5))
+    @test geomtrait(line) isa LineTrait
+    @test testgeometry(line)
+    @test ngeom(line) == 2
+    @test getgeom(line, 2) == Point(4, 5)
+    @test GeoInterface.coordinates(line) == [[2, 3], [4, 5]]
+
     mp = MultiPoint([point, point])
+    @test geomtrait(mp) isa MultiPointTrait
     @test testgeometry(mp)
     @test ngeom(mp) == 2
     @test getgeom(mp, 2) == point
     @test GeoInterface.coordinates(mp) == [[2, 3], [2, 3]]
 
     linestring = LineString(Point{2,Int}[(10, 10), (20, 20), (10, 40)])
+    @test geomtrait(linestring) isa LineStringTrait
     @test testgeometry(linestring)
     @test ngeom(linestring) == 3
     @test ncoord(linestring) == 2
@@ -21,22 +31,26 @@
     @test GeoInterface.coordinates(linestring) == [[10, 10], [20, 20], [10, 40]]
 
     multilinestring = MultiLineString([linestring, linestring])
+    @test geomtrait(multilinestring) isa MultiLineStringTrait
     @test testgeometry(multilinestring)
     @test GeoInterface.coordinates(multilinestring) ==
           [[[10, 10], [20, 20], [10, 40]], [[10, 10], [20, 20], [10, 40]]]
     @test ncoord(multilinestring) == 2
 
     poly = Polygon(rand(Point{2,Float32}, 5), [rand(Point{2,Float32}, 5)])
+    @test geomtrait(poly) isa PolygonTrait
     @test testgeometry(poly)
     @test length(GeoInterface.coordinates(poly)) == 2
     @test length(GeoInterface.coordinates(poly)[1]) == 5
 
     triangle = Triangle(point, point, point)
+    @test geomtrait(triangle) isa PolygonTrait # ?? should it be a Triangle trait
     @test testgeometry(triangle)
     @test length(GeoInterface.coordinates(triangle)) == 1
     @test length(GeoInterface.coordinates(triangle)[1]) == 3
 
     polys = MultiPolygon([poly, poly])
+    @test geomtrait(polys) isa MultiPolygonTrait
     @test testgeometry(polys)
     @test length(GeoInterface.coordinates(polys)) == 2
     @test length(GeoInterface.coordinates(polys)[1]) == 2

--- a/test/geointerface.jl
+++ b/test/geointerface.jl
@@ -93,19 +93,19 @@ end
     multilinestring_gb = GeoInterface.convert(GeometryBasics, multilinestring_json)
     multipolygon_gb = GeoInterface.convert(GeometryBasics, multipolygon_json)
     multipolygon_hole_gb = GeoInterface.convert(GeometryBasics, multipolygon_hole_json)
-
-    @test point_gb === Point{2, Float64}(30.1, 10.1)
-    @test point_3d_gb === Point{3, Float64}(30.1, 10.1, 5.1)
+    
+    @test point_gb === Point{2,Float32}(30.1, 10.1)
+    @test point_3d_gb === Point{3,Float32}(30.1, 10.1, 5.1)
     @test linestring_gb isa LineString
     @test length(linestring_gb) == 2
-    @test eltype(linestring_gb) == Line{2, Float64}
+    @test eltype(linestring_gb) == Line{2,Float32}
     @test polygon_gb isa Polygon
     @test isempty(polygon_gb.interiors)
     @test polygon_hole_gb isa Polygon
     @test length(polygon_hole_gb.interiors) == 1
     @test multipoint_gb isa MultiPoint
     @test length(multipoint_gb) == 4
-    @test multipoint_gb[4] === Point{2, Float64}(30.1, 10.1)
+    @test multipoint_gb[4] === Point{2,Float32}(30.1, 10.1)
     @test multilinestring_gb isa MultiLineString
     @test length(multilinestring_gb) == 2
     @test multipolygon_gb isa MultiPolygon


### PR DESCRIPTION
Vectors of geometries were defined as geometries here. But that breaks heaps of the interface as they don't actually return a `geomtrait`.

So removing. No tests as its just deleting things that are bugs.


Another tiny change is using `AbstractMesh` in `isgeometry` instead of `Mesh` because `geomtrait` uses `AbstractMesh`.