### PR TITLE
Add conversions for different parameter types of primitives

### DIFF
--- a/src/primitives/cylinders.jl
+++ b/src/primitives/cylinders.jl
@@ -105,3 +105,5 @@ function faces(c::Cylinder{3}, facets=30)
     end
     return indexes
 end
+
+Base.convert(::Type{CT}, c::Cylinder{N}) where {N, CT <: Cylinder{N}} = CT(c.origin, c.extremity, c.r)

--- a/src/primitives/pyramids.jl
+++ b/src/primitives/pyramids.jl
@@ -26,4 +26,4 @@ function faces(::Pyramid)
     return (TriangleFace(triangle) for triangle in TupleView{3}(1:18))
 end
 
-Base.convert(::Type{<: Pyramid}, c::Pyramid) = Pyramid(c.middle, c.length, c.width)
+Base.convert(::Type{PT}, c::Pyramid) where {PT <: Pyramid} = PT(c.middle, c.length, c.width)

--- a/src/primitives/pyramids.jl
+++ b/src/primitives/pyramids.jl
@@ -25,3 +25,5 @@ end
 function faces(::Pyramid)
     return (TriangleFace(triangle) for triangle in TupleView{3}(1:18))
 end
+
+Base.convert(::Type{<: Pyramid}, c::Pyramid) = Pyramid(c.middle, c.length, c.width)

--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -560,3 +560,5 @@ function faces(rect::Rect3)
     return QuadFace{Int}[(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16),
                          (17, 18, 19, 20), (21, 22, 23, 24),]
 end
+
+Base.convert(::Type{RT}, r::Rect{N}) where {N, RT <: Rect{N}} = RT(r.origin, r.widths)

--- a/src/primitives/spheres.jl
+++ b/src/primitives/spheres.jl
@@ -70,3 +70,5 @@ end
 function normals(s::Sphere{T}, nvertices=24) where {T}
     return coordinates(Sphere(Point{3,T}(0), 1), nvertices)
 end
+
+Base.convert(::Type{HST}, r::HyperSphere{N}) where {N, HST <: HyperSphere{N}} = HST(r.center, r.r)


### PR DESCRIPTION
Something like this currently errors
```julia
rs = [Rect2(0,0,1,1)]
rs[1] = Rect2f(0,0,1,1)
```
because there are no conversion functions for these types. This pr aims to fix this for https://github.com/MakieOrg/Makie.jl/pull/2573 which would make it more likely for these types to collide. 