### PR TITLE
Add Extents.extent method for Rect2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.7"
 
 [deps]
 EarCut_jll = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,6 +15,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 EarCut_jll = "2"
+Extents = "0.1"
 GeoInterface = "1.0.1"
 IterTools = "1.3.0"
 StaticArrays = "0.12, 1.0"

--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -2,6 +2,7 @@ module GeometryBasics
 
 using StaticArrays, Tables, StructArrays, IterTools, LinearAlgebra
 using GeoInterface
+import Extents
 using EarCut_jll
 
 using Base: @propagate_inbounds

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -149,3 +149,8 @@ function GeoInterface.convert(::Type{MultiPolygon}, type::MultiPolygonTrait, geo
     t = PolygonTrait()
     return MultiPolygon(map(poly -> GeoInterface.convert(Polygon, t, poly), getgeom(geom)))
 end
+
+function Extents.extent(rect::Rect2)
+    (xmin, ymin), (xmax, ymax) = extrema(rect)
+    return Extents.Extent(X=(xmin, xmax), Y=(ymin, ymax))
+end

--- a/test/geointerface.jl
+++ b/test/geointerface.jl
@@ -115,3 +115,10 @@ end
     @test length(multipolygon_hole_gb[1].interiors) == 0
     @test length(multipolygon_hole_gb[2].interiors) == 1
 end
+
+@testset "Extent" begin
+    rect = Rect2f(Vec2f(0), Vec2f(1.0))
+    ext = extent(rect)
+    @test ext.X == (0.0f0, 1.0f0)
+    @test ext.Y == (0.0f0, 1.0f0)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using LinearAlgebra
 using GeometryBasics: attributes
 using GeoInterface
 using GeoJSON
+using Extents
 
 @testset "GeometryBasics" begin
 


### PR DESCRIPTION
This has been pirated in Tyler and should rather live in GeometryBasics.
This would enable us to use this method in PyramidScheme without having to depend on Tyler for example. 

I put the definition into the GeoInterface file because for me the Extents is an extension of the GeoInterface. 

I am not sure, whether it would make sense to also provide the extent functionality also for higher dimensional rectangles or other geometry types, but the Rect2 is needed for the subsetting in Tyler.

@rafaqz 