### PR TITLE
add triangle_mesh shortcut

### DIFF
--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -175,6 +175,14 @@ function triangle_mesh(primitive::Meshable{N}; nvertices=nothing) where {N}
     return mesh(primitive; pointtype=Point{N,Float32}, facetype=GLTriangleFace)
 end
 
+function triangle_mesh(primitive::TriangleMesh{N}; nvertices=nothing) where {N}
+    if nvertices !== nothing
+        @warn("nvertices argument deprecated. Wrap primitive in `Tesselation(primitive, nvertices)`")
+        return mesh(Tesselation(primitive, nvertices); pointtype=Point{N,Float32}, facetype=GLTriangleFace)
+    end
+    return primitive
+end
+
 function uv_mesh(primitive::Meshable{N,T}) where {N,T}
     return mesh(primitive; pointtype=Point{N,Float32}, uv=Vec2f, facetype=GLTriangleFace)
 end


### PR DESCRIPTION
When plotting a vector of many meshes in 2D and 3D a large portion of time is taken up by `triangle_mesh` or more specifically `decompose_triangulate_fallback` to first decompose and then reassemble the meshes.

This PR makes `triangle_mesh(::TriangleMesh)` an identity operation.  


EDIT: this change does not yet yield the correct dispatch.
However, here's an example to show that it is worth it:

```
using GLMakie, GeometryBasics

julia> m = GeometryBasics.mesh([Point2f(0.0,0.0), Point2f(0.0,1.0), Point2f(1.0,0.0)], facetype = GLTriangleFace)
Mesh{2, Float32, Triangle}:
 Triangle(Float32[0.0, 0.0], Float32[1.0, 0.0], Float32[0.0, 1.0])

julia> mv = [deepcopy(m) for i=1:200000];

julia> @time mesh(mv) # second time
  1.179934 seconds (7.24 M allocations: 567.325 MiB, 6.40% gc time)

# here's an inelegant pass-through definition
julia> GeometryBasics.triangle_mesh(primitive::typeof(m)) = primitive

julia> @time mesh(mv) # second time
  0.064663 seconds (438.06 k allocations: 85.145 MiB, 34.41% gc time)
```
