### PR TITLE
improve merge(meshes)

### DIFF
--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -228,16 +228,22 @@ function Base.merge(meshes::AbstractVector{<:Mesh})
     elseif length(meshes) == 1
         return meshes[1]
     else
-        m1 = meshes[1]
-        ps = copy(coordinates(m1))
-        fs = copy(faces(m1))
+        ps = reduce(vcat, coordinates.(meshes))
+        fs = reduce(vcat, faces.(meshes))
+        idx = length(faces(meshes[1]))
+        offset = length(coordinates(meshes[1]))
         for mesh in Iterators.drop(meshes, 1)
-            append!(fs, map(f -> f .+ length(ps), faces(mesh)))
-            append!(ps, coordinates(mesh))
+            N = length(faces(mesh))
+            for i = idx .+ (1:N)
+                fs[i] = fs[i] .+ offset
+            end
+            idx += N
+            offset += length(coordinates(mesh))
         end
         return Mesh(ps, fs)
     end
 end
+
 
 """
     pointmeta(mesh::Mesh; meta_data...)


### PR DESCRIPTION
Brings allocations down to a fixed number and improves runtime by about x3 in our application.

Note: `reduce(vcat, ..)` plus broadcasting is faster than `mapreduce` for some reason