### PR TITLE
take ownership of triangulation memory - OOM errors

### DIFF
--- a/src/triangulation.jl
+++ b/src/triangulation.jl
@@ -183,7 +183,7 @@ function earcut_triangulate(polygon::Vector{Vector{Point{2,Float64}}})
     len = UInt32(length(lengths))
     array = ccall((:u32_triangulate_f64, libearcut), Tuple{Ptr{GLTriangleFace},Cint},
                   (Ptr{Ptr{Float64}}, Ptr{UInt32}, UInt32), polygon, lengths, len)
-    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2])
+    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2]; own=true)
 end
 
 function earcut_triangulate(polygon::Vector{Vector{Point{2,Float32}}})
@@ -191,7 +191,7 @@ function earcut_triangulate(polygon::Vector{Vector{Point{2,Float32}}})
     len = UInt32(length(lengths))
     array = ccall((:u32_triangulate_f32, libearcut), Tuple{Ptr{GLTriangleFace},Cint},
                   (Ptr{Ptr{Float32}}, Ptr{UInt32}, UInt32), polygon, lengths, len)
-    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2])
+    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2]; own=true)
 end
 
 function earcut_triangulate(polygon::Vector{Vector{Point{2,Int64}}})
@@ -199,7 +199,7 @@ function earcut_triangulate(polygon::Vector{Vector{Point{2,Int64}}})
     len = UInt32(length(lengths))
     array = ccall((:u32_triangulate_i64, libearcut), Tuple{Ptr{GLTriangleFace},Cint},
                   (Ptr{Ptr{Int64}}, Ptr{UInt32}, UInt32), polygon, lengths, len)
-    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2])
+    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2]; own=true)
 end
 
 function earcut_triangulate(polygon::Vector{Vector{Point{2,Int32}}})
@@ -207,7 +207,7 @@ function earcut_triangulate(polygon::Vector{Vector{Point{2,Int32}}})
     len = UInt32(length(lengths))
     array = ccall((:u32_triangulate_i32, libearcut), Tuple{Ptr{GLTriangleFace},Cint},
                   (Ptr{Ptr{Int32}}, Ptr{UInt32}, UInt32), polygon, lengths, len)
-    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2])
+    return unsafe_wrap(Vector{GLTriangleFace}, array[1], array[2]; own=true)
 end
 
 best_earcut_eltype(x) = Float64


### PR DESCRIPTION
Currently, I observe the following steady increase in memory upon repeated triangulations
eventually leading to OOM errors:
```
julia> using GeometryBasics

julia> points = Point2f.(reverse.(sincos.(0:0.01:2π)));

julia> triang = GeometryBasics.earcut_triangulate([points]);

julia> Sys.maxrss()/2^20
433.01171875

julia> @time for i=1:10^5
         GeometryBasics.earcut_triangulate([points]);
       end
 19.742204 seconds (500.00 k allocations: 30.518 MiB, 0.06% gc time)

julia> GC.gc(true)

julia> Sys.maxrss()/2^20
1156.88671875

julia> @time for i=1:10^5
         GeometryBasics.earcut_triangulate([points]);
       end
 19.175300 seconds (500.00 k allocations: 30.518 MiB)

julia> GC.gc(true)

julia> Sys.maxrss()/2^20
1873.0859375
```


With this PR:

```
julia> points = Point2f.(reverse.(sincos.(0:0.01:2π)));

julia> triang = GeometryBasics.earcut_triangulate([points]);

julia> Sys.maxrss()/2^20
411.16796875

julia> @time for i=1:10^5
         GeometryBasics.earcut_triangulate([points]);
       end
 21.869706 seconds (500.00 k allocations: 748.062 MiB, 1.02% gc time)

julia> GC.gc(true)

julia> Sys.maxrss()/2^20
438.33203125

julia> @time for i=1:10^5
         GeometryBasics.earcut_triangulate([points]);
       end
 21.142299 seconds (500.00 k allocations: 748.062 MiB, 0.17% gc time)

julia> GC.gc(true)

julia> Sys.maxrss()/2^20
438.33203125
```