### PR TITLE
dont use macro for aliases and introduce more variants (Float64 -> d, UInt -> ui)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -106,3 +106,40 @@ Use `GeometryBasics.mesh` to get a mesh directly from a geometry:
 ```@repl quickstart
 mesh = GeometryBasics.mesh(rect)
 ```
+
+
+## Aliases
+
+GeometryBasics exports common aliases for Point, Vec, Mat and Rect:
+
+### Vec
+
+|        |`T`(eltype) |`Float64` |`Float32` |`Int`     |`UInt`    |
+|--------|------------|----------|----------|----------|----------|
+|`N`(dim)|`Vec{N,T}`  |`Vecd{N}` |`Vecf{N}` |`Veci{N}` |`Vecui{N}`|
+|`2`     |`Vec2{T}`   |`Vec2d`   |`Vec2f`   |`Vec2i`   |`Vec2ui`  |
+|`3`     |`Vec3{T}`   |`Vec3d`   |`Vec3f`   |`Vec3i`   |`Vec3ui`  |
+
+### Point
+
+|        |`T`(eltype) |`Float64` |`Float32` |`Int`     |`UInt`    |
+|--------|------------|----------|----------|----------|----------|
+|`N`(dim)|`Point{N,T}`|`Pointd{N}`|`Pointf{N}`|`Pointi{N}`|`Pointui{N}`|
+|`2`     |`Point2{T}` |`Point2d` |`Point2f` |`Point2i` |`Point2ui`|
+|`3`     |`Point3{T}` |`Point3d` |`Point3f` |`Point3i` |`Point3ui`|
+
+### Mat
+
+|        |`T`(eltype) |`Float64` |`Float32` |`Int`     |`UInt`    |
+|--------|------------|----------|----------|----------|----------|
+|`N`(dim)|`Mat{N,T}`  |`Matd{N}` |`Matf{N}` |`Mati{N}` |`Matui{N}`|
+|`2`     |`Mat2{T}`   |`Mat2d`   |`Mat2f`   |`Mat2i`   |`Mat2ui`  |
+|`3`     |`Mat3{T}`   |`Mat3d`   |`Mat3f`   |`Mat3i`   |`Mat3ui`  |
+
+### Rect
+
+|        |`T`(eltype) |`Float64` |`Float32` |`Int`     |`UInt`    |
+|--------|------------|----------|----------|----------|----------|
+|`N`(dim)|`Rect{N,T}` |`Rectd{N}`|`Rectf{N}`|`Recti{N}`|`Rectui{N}`|
+|`2`     |`Rect2{T}`  |`Rect2d`  |`Rect2f`  |`Rect2i`  |`Rect2ui` |
+|`3`     |`Rect3{T}`  |`Rect3d`  |`Rect3f`  |`Rect3i`  |`Rect3ui` |

--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -66,7 +66,7 @@ export uv_mesh, normal_mesh, uv_normal_mesh
 export height, origin, radius, width, widths
 export HyperSphere, Circle, Sphere
 export Cylinder, Cylinder2, Cylinder3, Pyramid, extremity
-export HyperRectangle, Rect, Rect2, Rect3, Recti, Rect2i, Rect3i, Rectf, Rect2f, Rect3f
+export HyperRectangle, Rect, Rect2, Rect3, Recti, Rect2i, Rect3i, Rectf, Rect2f, Rect3f, Rectd, Rect2d, Rect3d
 export before, during, meets, overlaps, intersects, finishes
 export centered, direction, area, volume, update
 export max_dist_dim, max_euclidean, max_euclideansq, min_dist_dim, min_euclidean

--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -24,7 +24,7 @@ abstract type AbstractSimplex{Dim,N,T} <: StaticVector{Dim,T} end
 Face index, connecting points to form a simplex
 """
 
-@fixed_vector SimplexFace AbstractSimplexFace
+@fixed_vector SimplexFace = AbstractSimplexFace
 const TetrahedronFace{T} = SimplexFace{4,T}
 Face(::Type{<:SimplexFace{N}}, ::Type{T}) where {N,T} = SimplexFace{N,T}
 
@@ -32,7 +32,7 @@ Face(::Type{<:SimplexFace{N}}, ::Type{T}) where {N,T} = SimplexFace{N,T}
 Face index, connecting points to form an Ngon
 """
 
-@fixed_vector NgonFace AbstractNgonFace
+@fixed_vector NgonFace = AbstractNgonFace
 const LineFace{T} = NgonFace{2,T}
 const TriangleFace{T} = NgonFace{3,T}
 const QuadFace{T} = NgonFace{4,T}

--- a/src/fixed_arrays.jl
+++ b/src/fixed_arrays.jl
@@ -6,7 +6,9 @@ function unit(::Type{T}, i::Integer) where {T <: StaticVector}
     return T(tup)
 end
 
-macro fixed_vector(name, parent)
+macro fixed_vector(name_parent)
+    @assert name_parent.head == :(=)
+    name, parent = name_parent.args
     expr = quote
         struct $(name){S,T} <: $(parent){S,T}
             data::NTuple{S,T}
@@ -116,35 +118,42 @@ macro fixed_vector(name, parent)
 end
 
 abstract type AbstractPoint{Dim,T} <: StaticVector{Dim,T} end
-@fixed_vector Point AbstractPoint
-@fixed_vector Vec StaticVector
+
+@fixed_vector Point = AbstractPoint
+@fixed_vector Vec = StaticVector
+
+Base.isnan(p::Union{AbstractPoint,Vec}) = any(x -> isnan(x), p)
 
 const Mat = SMatrix
 const VecTypes{N,T} = Union{StaticVector{N,T},NTuple{N,T}}
 const Vecf{N} = Vec{N,Float32}
 const Pointf{N} = Point{N,Float32}
-Base.isnan(p::Union{AbstractPoint,Vec}) = any(x -> isnan(x), p)
 
-for i in 1:4
-    for T in [:Point, :Vec]
-        name = Symbol("$T$i")
-        namef = Symbol("$T$(i)f")
-        @eval begin
-            const $name = $T{$i}
-            const $namef = $T{$i,Float32}
-            export $name
-            export $namef
+## Generate aliases
+## As a text file instead of eval/macro, to not confuse code linter
+
+#=
+open(joinpath(@__DIR__, "generated-aliases.jl"), "w") do io
+    for i in 1:4
+        for T in [:Point, :Vec, :Mat]
+            namei = "$T$i"
+            res = T == :Mat ? "Mat{$i,$i,T,$(i * i)}" : "$T{$i,T}"
+            println(io, "const $(namei){T} = $res")
+            println(io, "export $namei")
+            for (postfix, t) in ["d" => Float64, "f" => Float32, "i" => Int, "ui" => UInt]
+                namep = "$T$i$postfix"
+                println(io, "const $(namep) = $(namei){$t}")
+                println(io, "export $namep")
+                # mnamep = "$(mname)$postfix"
+                # println(io, "const $mnamep = $mname{$t}")
+                # println(io, "export $mnamep")
+            end
         end
     end
-    name = Symbol("Mat$i")
-    namef = Symbol("Mat$(i)f")
-    @eval begin
-        const $name{T} = $Mat{$i,$i,T,$(i * i)}
-        const $namef = $name{Float32}
-        export $name
-        export $namef
-    end
 end
+=#
+
+include("generated-aliases.jl")
 
 export Mat, Vec, Point, unit
 export Vecf, Pointf

--- a/src/generated-aliases.jl
+++ b/src/generated-aliases.jl
@@ -1,0 +1,120 @@
+const Point1{T} = Point{1,T}
+export Point1
+const Point1d = Point1{Float64}
+export Point1d
+const Point1f = Point1{Float32}
+export Point1f
+const Point1i = Point1{Int64}
+export Point1i
+const Point1ui = Point1{UInt64}
+export Point1ui
+const Vec1{T} = Vec{1,T}
+export Vec1
+const Vec1d = Vec1{Float64}
+export Vec1d
+const Vec1f = Vec1{Float32}
+export Vec1f
+const Vec1i = Vec1{Int64}
+export Vec1i
+const Vec1ui = Vec1{UInt64}
+export Vec1ui
+const Mat1{T} = Mat{1,1,T,1}
+export Mat1
+const Mat1d = Mat1{Float64}
+export Mat1d
+const Mat1f = Mat1{Float32}
+export Mat1f
+const Mat1i = Mat1{Int64}
+export Mat1i
+const Mat1ui = Mat1{UInt64}
+export Mat1ui
+const Point2{T} = Point{2,T}
+export Point2
+const Point2d = Point2{Float64}
+export Point2d
+const Point2f = Point2{Float32}
+export Point2f
+const Point2i = Point2{Int64}
+export Point2i
+const Point2ui = Point2{UInt64}
+export Point2ui
+const Vec2{T} = Vec{2,T}
+export Vec2
+const Vec2d = Vec2{Float64}
+export Vec2d
+const Vec2f = Vec2{Float32}
+export Vec2f
+const Vec2i = Vec2{Int64}
+export Vec2i
+const Vec2ui = Vec2{UInt64}
+export Vec2ui
+const Mat2{T} = Mat{2,2,T,4}
+export Mat2
+const Mat2d = Mat2{Float64}
+export Mat2d
+const Mat2f = Mat2{Float32}
+export Mat2f
+const Mat2i = Mat2{Int64}
+export Mat2i
+const Mat2ui = Mat2{UInt64}
+export Mat2ui
+const Point3{T} = Point{3,T}
+export Point3
+const Point3d = Point3{Float64}
+export Point3d
+const Point3f = Point3{Float32}
+export Point3f
+const Point3i = Point3{Int64}
+export Point3i
+const Point3ui = Point3{UInt64}
+export Point3ui
+const Vec3{T} = Vec{3,T}
+export Vec3
+const Vec3d = Vec3{Float64}
+export Vec3d
+const Vec3f = Vec3{Float32}
+export Vec3f
+const Vec3i = Vec3{Int64}
+export Vec3i
+const Vec3ui = Vec3{UInt64}
+export Vec3ui
+const Mat3{T} = Mat{3,3,T,9}
+export Mat3
+const Mat3d = Mat3{Float64}
+export Mat3d
+const Mat3f = Mat3{Float32}
+export Mat3f
+const Mat3i = Mat3{Int64}
+export Mat3i
+const Mat3ui = Mat3{UInt64}
+export Mat3ui
+const Point4{T} = Point{4,T}
+export Point4
+const Point4d = Point4{Float64}
+export Point4d
+const Point4f = Point4{Float32}
+export Point4f
+const Point4i = Point4{Int64}
+export Point4i
+const Point4ui = Point4{UInt64}
+export Point4ui
+const Vec4{T} = Vec{4,T}
+export Vec4
+const Vec4d = Vec4{Float64}
+export Vec4d
+const Vec4f = Vec4{Float32}
+export Vec4f
+const Vec4i = Vec4{Int64}
+export Vec4i
+const Vec4ui = Vec4{UInt64}
+export Vec4ui
+const Mat4{T} = Mat{4,4,T,16}
+export Mat4
+const Mat4d = Mat4{Float64}
+export Mat4d
+const Mat4f = Mat4{Float32}
+export Mat4f
+const Mat4i = Mat4{Int64}
+export Mat4i
+const Mat4ui = Mat4{UInt64}
+export Mat4ui

--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -174,6 +174,9 @@ function Rect3f(x::Tuple{Tuple{<:Number,<:Number,<:Number},
     return Rect3f(Vec3f(x[1]...), Vec3f(x[2]...))
 end
 
+# allow auto-conversion between different eltypes
+Base.convert(::Type{Rect{N, T}}, r::Rect{N}) where {N, T} = Rect{N, T}(r)
+
 origin(prim::Rect) = prim.origin
 Base.maximum(prim::Rect) = origin(prim) + widths(prim)
 Base.minimum(prim::Rect) = origin(prim)

--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -19,34 +19,37 @@ end
 
 A rectangle in N dimensions, formally the cartesian product of intervals. See also [`HyperRectangle`](@ref). Its aliases are
 
-|        |`T`(eltype)|`Float32` |`Int`     |
-|--------|-----------|----------|----------|
-|`N`(dim)|`Rect{N,T}`|`Rectf{N}`|`Recti{N}`|
-|`2`     |`Rect2{T}` |`Rect2f`  |`Rect2i`  |
-|`3`     |`Rect3{T}` |`Rect3f`  |`Rect3i`  |
+|        |`T`(eltype)|`Float64` |`Float32` |`Int`     |
+|--------|-----------|----------|----------|----------|
+|`N`(dim)|`Rect{N,T}`|`Rectd{N}`|`Rectf{N}`|`Recti{N}`|
+|`2`     |`Rect2{T}` |`Rect2d`  |`Rect2f`  |`Rect2i`  |
+|`3`     |`Rect3{T}` |`Rect3d`  |`Rect3f`  |`Rect3i`  |
 
 There is an additional unexported alias `RectT` that simply reverses the order of type parameters: `RectT{T,N} == Rect{N,T}`.
 
 """
-Rect, Rect2, Rect3, RectT, Rectf, Rect2f, Rect3f, Recti, Rect2i, Rect3i
+Rect, Rect2, Rect3, RectT, Rectd, Rect2d, Rect3d, Rectf, Rect2f, Rect3f, Recti, Rect2i, Rect3i
 
 const Rect{N,T} = HyperRectangle{N,T}
 const Rect2{T} = Rect{2,T}
 const Rect3{T} = Rect{3,T}
-const RectT{T} = Rect{N,T} where {N}
+
+const RectT{T,N} = Rect{N,T}
+
+const Rectd{N} = Rect{N,Float64}
+const Rect2d = Rect2{Float64}
+const Rect3d = Rect3{Float64}
 
 const Rectf{N} = Rect{N,Float32}
 const Rect2f = Rect2{Float32}
 const Rect3f = Rect3{Float32}
 
-const Recti{N} = HyperRectangle{N,Int}
+const Recti{N} = Rect{N,Int}
 const Rect2i = Rect2{Int}
 const Rect3i = Rect3{Int}
 
 Rect() = Rect{2,Float32}()
-
 RectT{T}() where {T} = Rect{2,T}()
-
 Rect{N}() where {N} = Rect{N,Float32}()
 
 function Rect{N,T}() where {T,N}


### PR DESCRIPTION
This PR makes all aliases recognizable by the linter and adds missing ones.