### PR TITLE
Implement `isinf` and `isfinite` for `Point` and `Vec`

### DIFF
--- a/src/fixed_arrays.jl
+++ b/src/fixed_arrays.jl
@@ -123,7 +123,9 @@ const Mat = SMatrix
 const VecTypes{N,T} = Union{StaticVector{N,T},NTuple{N,T}}
 const Vecf{N} = Vec{N,Float32}
 const Pointf{N} = Point{N,Float32}
-Base.isnan(p::Union{AbstractPoint,Vec}) = any(x -> isnan(x), p)
+Base.isnan(p::Union{AbstractPoint,Vec}) = any(isnan, p)
+Base.isinf(p::Union{AbstractPoint,Vec}) = any(isinf, p)
+Base.isfinite(p::Union{AbstractPoint,Vec}) = any(isfinite, p)
 
 for i in 1:4
     for T in [:Point, :Vec]

--- a/src/fixed_arrays.jl
+++ b/src/fixed_arrays.jl
@@ -125,7 +125,7 @@ const Vecf{N} = Vec{N,Float32}
 const Pointf{N} = Point{N,Float32}
 Base.isnan(p::Union{AbstractPoint,Vec}) = any(isnan, p)
 Base.isinf(p::Union{AbstractPoint,Vec}) = any(isinf, p)
-Base.isfinite(p::Union{AbstractPoint,Vec}) = any(isfinite, p)
+Base.isfinite(p::Union{AbstractPoint,Vec}) = all(isfinite, p)
 
 for i in 1:4
     for T in [:Point, :Vec]

--- a/test/fixed_arrays.jl
+++ b/test/fixed_arrays.jl
@@ -14,3 +14,20 @@ end
         @test [T(0, 0), T(5, 0)] == x .- T(2, 3)
     end
 end
+
+@testset "finite, nan, inf tests" begin
+    for T in (Vec, Point)
+        @testset "$T" begin
+            nan_point = T(Float64.((1.0, 2.0, 3.0, NaN)))
+            inf_point = T(Float64.((1.0, 2.0, Inf, 4.0)))
+            @test isinf(inf_point)
+            @test !isinf(nan_point)
+            @test isnan(nan_point)
+            @test !isnan(inf_point)
+            @test !isfinite(nan_point)
+            @test !isfinite(inf_point)
+            @test !isfinite(nan_point + inf_point)
+            @test isfinite(T(1, 2, 3))
+        end
+    end
+end


### PR DESCRIPTION
Also cleans up the implementation to use the functions directly and avoid anonymous functions.

This upstreams some type piracy which I've been doing in GeoMakie for a while.