### PR TITLE
rename `tesselation` to `tessellation`

### DIFF
--- a/docs/src/primitives.md
+++ b/docs/src/primitives.md
@@ -19,9 +19,9 @@ r2 = Rect3f(Point3f(-1), Vec3f(2))
 r3 = Rect2i(0, 0, 1, 1)
 ```
 
-Rect2 supports normal and texture coordinate generation as well as tesselation.
-Without tesselation, the coordinates of 2D Rects are defined in anti-clockwise order.
-Rect3 supports normals and texture coordinates, but not tesselation.
+Rect2 supports normal and texture coordinate generation as well as tessellation.
+Without tessellation, the coordinates of 2D Rects are defined in anti-clockwise order.
+Rect3 supports normals and texture coordinates, but not tessellation.
 
 Shorthands:
 
@@ -44,7 +44,7 @@ s2 = Sphere(Point3f(0, 0, 1), 1)
 s3 = Circle(Point2d(0), 2.0)
 ```
 
-Circle and Sphere support normal and texture coordinate generation as well as tesselation.
+Circle and Sphere support normal and texture coordinate generation as well as tessellation.
 The coordinates of Circle are defined in anti-clockwise order.
 
 #### Cylinder
@@ -55,7 +55,7 @@ A `Cylinder` is a 3D shape defined by two points and a radius.
 c = Cylinder(Point3f(-1, 0, 0), Point3f(0, 0, 1), 0.3f0) # start point, end point, radius
 ```
 
-Cylinder supports normals an Tesselation, but currently no texture coordinates.
+Cylinder supports normals an Tessellation, but currently no texture coordinates.
 
 #### Pyramid
 
@@ -67,18 +67,18 @@ It is defined by by the center point of the base, its height and its width.
 p = Pyramid(Point3f(0), 1f0, 0.3f0) # center, height, width
 ```
 
-Pyramid supports normals, but currently no texture coordinates or tesselation
+Pyramid supports normals, but currently no texture coordinates or tessellation
 
-## Tesselation
+## Tessellation
 
-In GeometryBasics `Tesselation` is a wrapper type for primitives which communicates
+In GeometryBasics `Tessellation` is a wrapper type for primitives which communicates
 how dense the mesh generated from one should be.
 
-```@repl tesselation
-t = Tesselation(Cylinder(Point3f(0), Point3f(0,0,1), 0.2), 32) # 32 vertices for each circle
+```@repl tessellation
+t = Tessellation(Cylinder(Point3f(0), Point3f(0,0,1), 0.2), 32) # 32 vertices for each circle
 normal_mesh(t)
 
-t = Tesselation(Rect2(Point2f(0), Vec2f(1)), (8, 6)) # 8 vertices in x direction by 6 in y direction
+t = Tessellation(Rect2(Point2f(0), Vec2f(1)), (8, 6)) # 8 vertices in x direction by 6 in y direction
 triangle_mesh(t)
 ```
 
@@ -89,8 +89,8 @@ This will also be enough to automatically generate normals for a 3D primitive an
 You can also implement functions to generate them directly with `normals(primitive)` and `texturecoordinates(primitive)`.
 Depending on your primitive this might be necessary to get the normals and uvs you want.
 
-To be compatible with `Tesselation` all of the functions mentioned above should implement a second tesselation argument.
-This will be the second argument passed to the Tesselation constructor.
+To be compatible with `Tessellation` all of the functions mentioned above should implement a second tessellation argument.
+This will be the second argument passed to the Tessellation constructor.
 It's up to you to decide what makes sense here, though typically it's just an integer that more or less corresponds to the number of generated vertices.
 
 #### Example

--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -43,7 +43,7 @@ export decompose, coordinates, faces, normals, decompose_uv, decompose_normals,
        texturecoordinates, vertex_attributes
 export expand_faceviews
 export face_normals
-export Tesselation, Normal, UV, UVW
+export Tessellation, Normal, UV, UVW
 export AbstractMesh, Mesh, MetaMesh, FaceView
 
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -58,58 +58,58 @@ something like `Vec2f`.
 texturecoordinates(primitive, nvertices=nothing) = nothing
 
 """
-    Tesselation(primitive, nvertices)
+    Tessellation(primitive, nvertices)
 
 When generating a mesh from an abstract geometry, we can typically generate it
 at different levels of detail, i.e. with different amounts of vertices. The 
-`Tesselation` wrapper allows you to specify this level of detail. When generating
+`Tessellation` wrapper allows you to specify this level of detail. When generating
 a mesh from a tesselated geometry, the added information will be passed to 
 `coordinates`, `faces`, etc.
 
 ```julia
 sphere = Sphere(Point3f(0), 1)
-m1 = mesh(sphere) # uses a default value for tesselation
-m2 = mesh(Tesselation(sphere, 64)) # uses 64 for tesselation
+m1 = mesh(sphere) # uses a default value for tessellation
+m2 = mesh(Tessellation(sphere, 64)) # uses 64 for tessellation
 length(coordinates(m1)) != length(coordinates(m2))
 ```
 
-For grid based tesselation, you can also use a tuple:
+For grid based tessellation, you can also use a tuple:
 
 ```julia
 rect = Rect2(0, 0, 1, 1)
-Tesselation(rect, (5, 5))
+Tessellation(rect, (5, 5))
 ```
 """
-struct Tesselation{Dim,T,Primitive,NGrid} <: AbstractGeometry{Dim, T}
+struct Tessellation{Dim,T,Primitive,NGrid} <: AbstractGeometry{Dim, T}
     primitive::Primitive
     nvertices::NTuple{NGrid,Int}
 end
 
-function Tesselation(primitive::GeometryPrimitive{Dim,T},
+function Tessellation(primitive::GeometryPrimitive{Dim,T},
                      nvertices::NTuple{N,<:Integer}) where {Dim,T,N}
-    return Tesselation{Dim,T,typeof(primitive),N}(primitive, Int.(nvertices))
+    return Tessellation{Dim,T,typeof(primitive),N}(primitive, Int.(nvertices))
 end
 
-Tesselation(primitive, nvertices::Integer) = Tesselation(primitive, (nvertices,))
+Tessellation(primitive, nvertices::Integer) = Tessellation(primitive, (nvertices,))
 
 # This is a bit lazy, I guess we should just refactor these methods
-# to directly work on Tesselation - but this way it's backward compatible and less
+# to directly work on Tessellation - but this way it's backward compatible and less
 # refactor work :D
-nvertices(tesselation::Tesselation) = tesselation.nvertices
-nvertices(tesselation::Tesselation{T,N,P,1}) where {T,N,P} = tesselation.nvertices[1]
+nvertices(tessellation::Tessellation) = tessellation.nvertices
+nvertices(tessellation::Tessellation{T,N,P,1}) where {T,N,P} = tessellation.nvertices[1]
 
-function coordinates(tesselation::Tesselation)
-    return coordinates(tesselation.primitive, nvertices(tesselation))
+function coordinates(tessellation::Tessellation)
+    return coordinates(tessellation.primitive, nvertices(tessellation))
 end
-faces(tesselation::Tesselation) = faces(tesselation.primitive, nvertices(tesselation))
-normals(tesselation::Tesselation) = normals(tesselation.primitive, nvertices(tesselation))
-function texturecoordinates(tesselation::Tesselation)
-    return texturecoordinates(tesselation.primitive, nvertices(tesselation))
+faces(tessellation::Tessellation) = faces(tessellation.primitive, nvertices(tessellation))
+normals(tessellation::Tessellation) = normals(tessellation.primitive, nvertices(tessellation))
+function texturecoordinates(tessellation::Tessellation)
+    return texturecoordinates(tessellation.primitive, nvertices(tessellation))
 end
 
 ## Decompose methods
 # Dispatch type to make `decompose(UV{Vec2f}, primitive)` work
-# and to pass through tesselation information
+# and to pass through tessellation information
 
 struct UV{T} end
 UV(::Type{T}) where {T} = UV{T}()

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -63,7 +63,7 @@ texturecoordinates(primitive, nvertices=nothing) = nothing
 When generating a mesh from an abstract geometry, we can typically generate it
 at different levels of detail, i.e. with different amounts of vertices. The 
 `Tessellation` wrapper allows you to specify this level of detail. When generating
-a mesh from a tesselated geometry, the added information will be passed to 
+a mesh from a tessellated geometry, the added information will be passed to 
 `coordinates`, `faces`, etc.
 
 ```julia
@@ -84,6 +84,8 @@ struct Tessellation{Dim,T,Primitive,NGrid} <: AbstractGeometry{Dim, T}
     primitive::Primitive
     nvertices::NTuple{NGrid,Int}
 end
+
+Base.@deprecate_binding Tesselation Tessellation
 
 function Tessellation(primitive::GeometryPrimitive{Dim,T},
                      nvertices::NTuple{N,<:Integer}) where {Dim,T,N}

--- a/src/precompiles.jl
+++ b/src/precompiles.jl
@@ -27,7 +27,7 @@ using PrecompileTools: @setup_workload, @compile_workload
 
         # Other primitives
         uv_normal_mesh(Rect2(0,0,1,1))
-        uv_normal_mesh(Tesselation(Sphere(Point3f(0), 1f0), 3))
+        uv_normal_mesh(Tessellation(Sphere(Point3f(0), 1f0), 3))
         uv_normal_mesh(Cylinder(Point3f(0), Point3f(0,0,1), 1f0))
         uv_normal_mesh(Pyramid(Point3f(0), 1f0, 1f0))
 

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -33,16 +33,16 @@ using Test, GeometryBasics
             (4, 5, 6)
         ]
 
-        @test decompose(Point3{Float64}, Tesselation(s, 8)) ≈ positions
+        @test decompose(Point3{Float64}, Tessellation(s, 8)) ≈ positions
 
         _faces = TriangleFace[
             (9, 2, 1), (9, 3, 2), (9, 4, 3), (9, 1, 4), (1, 2, 6), (1, 6, 5), 
             (2, 3, 7), (2, 7, 6), (3, 4, 8), (3, 8, 7), (4, 1, 5), (4, 5, 8), 
             (10, 5, 6), (10, 6, 7), (10, 7, 8), (10, 8, 5)]
 
-        @test _faces == decompose(TriangleFace{Int}, Tesselation(s, 8))
+        @test _faces == decompose(TriangleFace{Int}, Tessellation(s, 8))
 
-        m = triangle_mesh(Tesselation(s, 8))
+        m = triangle_mesh(Tessellation(s, 8))
         @test m === triangle_mesh(m)
         @test GeometryBasics.faces(m) == decompose(GLTriangleFace, _faces)
         @test GeometryBasics.coordinates(m) ≈ positions
@@ -69,7 +69,7 @@ using Test, GeometryBasics
             ]
         )
 
-        @test ns == decompose_normals(Tesselation(s, 8))
+        @test ns == decompose_normals(Tessellation(s, 8))
 
         muv = uv_mesh(s)
         @test !hasproperty(muv, :uv) # not defined yet
@@ -168,7 +168,7 @@ end
 @testset "HyperSphere" begin
     sphere = Sphere{Float32}(Point3f(0), 1.0f0)
 
-    points = decompose(Point, Tesselation(sphere, 3))
+    points = decompose(Point, Tessellation(sphere, 3))
     point_target = Point{3,Float32}[[0.0, 0.0, 1.0], [1.0, 0.0, 6.12323e-17],
                                     [1.22465e-16, 0.0, -1.0], [-0.0, 0.0, 1.0],
                                     [-1.0, 1.22465e-16, 6.12323e-17],
@@ -177,14 +177,14 @@ end
                                     [1.22465e-16, -2.99952e-32, -1.0]]
     @test points ≈ point_target
 
-    f = decompose(TriangleFace{Int}, Tesselation(sphere, 3))
+    f = decompose(TriangleFace{Int}, Tessellation(sphere, 3))
     face_target = TriangleFace{Int}[[1, 2, 5], [1, 5, 4], [2, 3, 6], [2, 6, 5], [4, 5, 8],
                                     [4, 8, 7], [5, 6, 9], [5, 9, 8]]
     @test f == face_target
     circle = Circle(Point2f(0), 1.0f0)
-    points = decompose(Point2f, Tesselation(circle, 20))
+    points = decompose(Point2f, Tessellation(circle, 20))
     @test length(points) == 20
-    tess_circle = Tesselation(circle, 32)
+    tess_circle = Tessellation(circle, 32)
     mesh = triangle_mesh(tess_circle)
     @test decompose(Point2f, mesh) ≈ decompose(Point2f, tess_circle)
 end

--- a/test/polygons.jl
+++ b/test/polygons.jl
@@ -6,7 +6,7 @@
     end
 
     rect = Rect2f(0, 0, 1, 1)
-    hole = Tesselation(Circle(Point2f(0.5), 0.2), 8)
+    hole = Tessellation(Circle(Point2f(0.5), 0.2), 8)
     poly2 = Polygon(decompose(Point2f, rect), [decompose(Point2f, hole)])
     poly1 = Polygon(rect, [hole])
     @test poly1 == poly2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,7 +141,7 @@ end
         mesh = Mesh(points, tfaces)
         meshuv = MetaMesh(points, tfaces; uv=uv)
         meshuvnormal = MetaMesh(points, tfaces; normal=ns, uv=uv)
-        t = Tesselation(Rect2f(0, 0, 2, 2), (30, 30))
+        t = Tessellation(Rect2f(0, 0, 2, 2), (30, 30))
 
         m = GeometryBasics.mesh(t; pointtype=Point3f, facetype=QuadFace{Int})
         m2 = GeometryBasics.mesh(m, facetype=QuadFace{GLIndex})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,6 +310,12 @@ end
     include("geointerface.jl")
 end
 
+@testset "Deprecations" begin
+    # https://github.com/JuliaLang/julia/issues/38780
+    # @test_warn Tesselation(Rect2f(0, 0, 2, 2), 10)
+    @test Tesselation(Rect2f(0, 0, 2, 2), 10) ==  Tessellation(Rect2f(0, 0, 2, 2), 10)
+end
+
 include("polygons.jl")
 
 using Aqua


### PR DESCRIPTION
Fix https://github.com/JuliaGeometry/GeometryBasics.jl/issues/224.

EDIT: now non-breaking: the deprecated binding `Tesselation` is kept and can be removed later.