### PR TITLE
Use shoelace approach to compute normals

### DIFF
--- a/src/fixed_arrays.jl
+++ b/src/fixed_arrays.jl
@@ -145,6 +145,13 @@ Base.isnan(p::Union{AbstractPoint,Vec}) = any(isnan, p)
 Base.isinf(p::Union{AbstractPoint,Vec}) = any(isinf, p)
 Base.isfinite(p::Union{AbstractPoint,Vec}) = all(isfinite, p)
 
+function to_ndim(T::Type{<: VecTypes{N, ET}}, vec::VecTypes{N2}, fillval) where {N,ET,N2}
+    T(ntuple(Val(N)) do i
+        i > N2 && return ET(fillval)
+        @inbounds return vec[i]
+    end)
+end
+
 ## Generate aliases
 ## As a text file instead of eval/macro, to not confuse code linter
 

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -175,7 +175,7 @@ end
 
 function normals(vertices::AbstractVector{<:Point{3}}, faces::AbstractVector{<: NgonFace},
                  ::Type{NormalType}) where {NormalType}
-    println("WOOOHOOOO")                 
+                                  
     normals_result = zeros(NormalType, length(vertices))
     for face in faces
         v = vertices[face]

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -165,6 +165,9 @@ end
 
 # derive target type
 orthogonal_vector(vertices::Ngon{D, T}) where {D, T} = orthogonal_vector(Vec3{T}, vertices)
+function orthogonal_vector(vertices::NTuple{N, VT}) where {N, D, T, VT <: VecTypes{D, T}}
+    return orthogonal_vector(Vec3{T}, vertices)
+end
 function orthogonal_vector(vertices::AbstractArray{VT}) where {D, T, VT <: VecTypes{D, T}}
     return orthogonal_vector(Vec3{T}, vertices)
 end

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -162,7 +162,13 @@ function orthogonal_vector(::Type{VT}, triangle::Triangle) where {VT <: VecTypes
     a, b, c = triangle
     return cross(to_ndim(VT, b-a, 0), to_ndim(VT, c-a, 0))
 end
+
+# derive target type
+orthogonal_vector(vertices::Ngon{D, T}) where {D, T} = orthogonal_vector(Vec3{T}, vertices)
+function orthogonal_vector(vertices::AbstractArray{VT}) where {D, T, VT <: VecTypes{D, T}}
+    return orthogonal_vector(Vec3{T}, vertices)
 end
+# fallback to Vec3f if vertices is something else
 orthogonal_vector(vertices) = orthogonal_vector(Vec3f, vertices)
 
 """

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -157,9 +157,13 @@ function orthogonal_vector(::Type{VT},vertices) where VT
     return c
 end
 
-function orthogonal_vector(vertices)
-    return orthogonal_vector(eltype(vertices),vertices)
+# Not sure how useful this fast path is, but it's simple to keep
+function orthogonal_vector(::Type{VT}, triangle::Triangle) where {VT <: VecTypes{3}}
+    a, b, c = triangle
+    return cross(to_ndim(VT, b-a, 0), to_ndim(VT, c-a, 0))
 end
+end
+orthogonal_vector(vertices) = orthogonal_vector(Vec3f, vertices)
 
 """
     normals(positions::Vector{Point3{T}}, faces::Vector{<: NgonFace}[; normaltype = Vec3{T}])

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -145,11 +145,24 @@ end
 Calculates an orthogonal vector to a polygon defined by a vector of ordered
 `points`. Note that the orthogonal vector to a collection of 2D points needs to
 expand to 3D space.
+
+Note that this vector is not normalized.
 """
 function orthogonal_vector(::Type{VT}, vertices) where {VT <: VecTypes{3}}
     c = zeros(VT) # Inherit vector type from input
     prev = to_ndim(VT, last(coordinates(vertices)), 0)
     @inbounds for p in coordinates(vertices) # Use shoelace approach
+        v = to_ndim(VT, p, 0)
+        c += cross(prev, v) # Add each edge contribution
+        prev = v
+    end
+    return c
+end
+
+function orthogonal_vector(::Type{VT}, vertices::Tuple) where {VT <: VecTypes{3}}
+    c = zeros(VT) # Inherit vector type from input
+    prev = to_ndim(VT, last(vertices), 0)
+    @inbounds for p in vertices # Use shoelace approach
         v = to_ndim(VT, p, 0)
         c += cross(prev, v) # Add each edge contribution
         prev = v

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -213,8 +213,9 @@ end
 Calculate the signed volume of one tetrahedron. Be sure the orientation of your
 surface is right.
 """
-function volume(triangle::Triangle)    
-    sig = sign(orthogonal_vector(triangle.points) ⋅ v1)
+function volume(triangle::Triangle{3, T}) where {T}
+    v1, v2, v3 = triangle
+    sig = sign(orthogonal_vector(Vec3{T}, triangle) ⋅ v1)
     return sig * abs(v1 ⋅ (v2 × v3)) / 6
 end
 

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -213,9 +213,8 @@ end
 Calculate the signed volume of one tetrahedron. Be sure the orientation of your
 surface is right.
 """
-function volume(triangle::Triangle)
-    v1, v2, v3 = triangle
-    sig = sign(orthogonal_vector(v1, v2, v3) ⋅ v1)
+function volume(triangle::Triangle)    
+    sig = sign(orthogonal_vector(triangle.points) ⋅ v1)
     return sig * abs(v1 ⋅ (v2 × v3)) / 6
 end
 

--- a/src/triangulation.jl
+++ b/src/triangulation.jl
@@ -13,53 +13,42 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =#
 """
-    area(vertices::AbstractVector{Point{3}}, face::TriangleFace)
+    area(vertices::AbstractVector{Point{3}}, face::NgonFace)
 
-Calculate the area of one triangle.
+Calculate the area of one face.
 """
-function area(vertices::AbstractVector{<:Point{3,VT}},
-              face::TriangleFace{FT}) where {VT,FT}
-    v1, v2, v3 = vertices[face]
-    return 0.5 * norm(orthogonal_vector(v1, v2, v3))
+function area(vertices::AbstractVector{<:Point},
+              face::NgonFace)
+    return 0.5 * norm(orthogonal_vector(vertices[face]))
 end
 
 """
-    area(vertices::AbstractVector{Point{3}}, faces::AbstractVector{TriangleFace})
+    area(vertices::AbstractVector{Point}, faces::AbstractVector{NgonFace})
 
-Calculate the area of all triangles.
+Calculate the area of all faces.
 """
-function area(vertices::AbstractVector{Point{3,VT}},
-              faces::AbstractVector{TriangleFace{FT}}) where {VT,FT}
+function area(vertices::AbstractVector{<:Point},
+              faces::AbstractVector{<:NgonFace})
     return sum(x -> area(vertices, x), faces)
 end
 
 """
-    area(contour::AbstractVector{Point}})
+    area(vertices::AbstractVector{Point}})
 
 Calculate the area of a polygon.
 
 For 2D points, the oriented area is returned (negative when the points are
 oriented clockwise).
 """
-function area(contour::AbstractVector{Point{2,T}}) where {T}
-    length(contour) < 3 && return zero(T)
-    A = zero(T)
-    p = lastindex(contour)
-    for q in eachindex(contour)
-        A += cross(contour[p], contour[q])
-        p = q
-    end
-    return A * T(0.5)
+function area(vertices::AbstractVector{Point{2,T}}) where {T}
+    length(vertices) < 3 && return zero(T)       
+    return T(0.5) * orthogonal_vector(vertices) 
 end
 
-function area(contour::AbstractVector{Point{3,T}}) where {T}
-    A = zero(eltype(contour))
-    o = first(contour)
-    for i in (firstindex(contour) + 1):(lastindex(contour) - 1)
-        A += cross(contour[i] - o, contour[i + 1] - o)
-    end
-    return norm(A) * T(0.5)
+function area(vertices::AbstractVector{Point{3,T}}) where {T}
+    return T(0.5) * norm(orthogonal_vector(vertices))
 end
+
 
 """
     in(point, triangle)

--- a/src/triangulation.jl
+++ b/src/triangulation.jl
@@ -17,8 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Calculate the area of one face.
 """
-function area(vertices::AbstractVector{<:Point},
-              face::NgonFace)
+function area(vertices::AbstractVector{<:Point}, face::NgonFace)
     return 0.5 * norm(orthogonal_vector(vertices[face]))
 end
 
@@ -27,8 +26,7 @@ end
 
 Calculate the area of all faces.
 """
-function area(vertices::AbstractVector{<:Point},
-              faces::AbstractVector{<:NgonFace})
+function area(vertices::AbstractVector{<:Point}, faces::AbstractVector{<:NgonFace})
     return sum(x -> area(vertices, x), faces)
 end
 
@@ -41,11 +39,12 @@ For 2D points, the oriented area is returned (negative when the points are
 oriented clockwise).
 """
 function area(vertices::AbstractVector{Point{2,T}}) where {T}
-    length(vertices) < 3 && return zero(T)       
-    return T(0.5) * orthogonal_vector(vertices) 
+    length(vertices) < 3 && return zero(T)
+    return T(0.5) * orthogonal_vector(vertices)[3]
 end
 
 function area(vertices::AbstractVector{Point{3,T}}) where {T}
+    length(vertices) < 3 && return zero(T)
     return T(0.5) * norm(orthogonal_vector(vertices))
 end
 

--- a/test/fixed_arrays.jl
+++ b/test/fixed_arrays.jl
@@ -1,4 +1,5 @@
 using Test
+using GeometryBasics: to_ndim
 
 @testset "Construction and Conversion" begin
     for VT in [Point, Vec]
@@ -19,6 +20,10 @@ using Test
 
     @test convert(Point, (2, 3)) === Point(2, 3)
     @test convert(Point, (2.0, 3)) === Point(2.0, 3.0)
+
+    @test to_ndim(Point3f, Vec2i(1,2), 0) == Point3f(1,2,0)
+    @test to_ndim(Vec4i, (1f0, 2), 0) == Vec4i(1,2,0,0)
+    @test to_ndim(NTuple{2, Float64}, Point3f(1,2,3), 0) == (1.0, 2.0)
 end
 
 @testset "broadcast" begin

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -351,12 +351,31 @@ end
     ns = normals(c)
     # caps without mantle
     f_ns = face_normals(coordinates(c), filter!(f -> f isa TriangleFace, faces(c)))
-    @test all(n -> n == values(ns)[end-1], values(f_ns)[1:15])
-    @test all(n -> n == values(ns)[end], values(f_ns)[16:end])
+    @test all(n -> n ≈ values(ns)[end-1], values(f_ns)[1:15])
+    @test all(n -> n ≈ values(ns)[end], values(f_ns)[16:end])
     # Mantle without caps
     v_ns = normals(coordinates(c), filter!(f -> f isa QuadFace, faces(c)))[1:end-2]
     @test values(ns)[1:15] ≈ v_ns[1:15]
     @test values(ns)[1:15] ≈ v_ns[16:30] # repeated via FaceView in ns
+
+    # Planar QuadFace with colinear edge 
+    v = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(2.0,0.0,0.0),Point{3,Float64}(2.0,1.0,0.0)]
+    f = [QuadFace{Int}(1,2,3,4)]
+    n = normals(v,f)
+    @test all(n_i -> n_i ≈ [0.0,0.0,1.0], n)
+
+    # Planar NgonFace (5-sided) with colinear edge 
+    v = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(2.0,0.0,0.0),Point{3,Float64}(2.0,1.0,0.0),Point{3,Float64}(2.0,0.5,0.0)]
+    f = [NgonFace{5,Int}(1,2,3,4,5)]
+    n = normals(v,f)
+    @test all(n_i -> n_i ≈ [0.0,0.0,1.0], n)
+
+    # Non-planar NgonFace (6 sided), features equal up and down variations resulting in z-dir average face_normal    
+    t = range(0.0,2*pi-(2*pi)/6,6)
+    v = [Point{3,Float64}(cos(t[i]),sin(t[i]),iseven(i)) for i in eachindex(t)]
+    f = [NgonFace{6,Int}(1,2,3,4,5,6)]
+    n = normals(v,f)
+    @test all(n_i -> n_i ≈ [0.0,0.0,1.0], n)
 end
 
 @testset "HyperSphere" begin

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -332,6 +332,16 @@ end
     @test length(fv) == 5
 end
 
+@testset "orthogonal_vector" begin
+    tri = Triangle(Point3d(0,0,0), Point3d(1,0,0), Point3d(0,1,0))
+    @test GeometryBasics.orthogonal_vector(tri) == Vec3d(0,0,1)
+    @test GeometryBasics.orthogonal_vector(collect(coordinates(tri))) == Vec3d(0,0,1)
+
+    quad = GeometryBasics.Quadrilateral(Point2i(0,0), Point2i(1,0), Point2i(1,1), Point2i(0,1))
+    @test GeometryBasics.orthogonal_vector(quad) == Vec3i(0,0,2)
+    @test GeometryBasics.orthogonal_vector(collect(coordinates(quad))) == Vec3i(0,0,2)
+end
+
 @testset "Normals" begin
     # per face normals
     r = Rect3f(Point3f(0), Vec3f(1))
@@ -358,19 +368,19 @@ end
     @test values(ns)[1:15] ≈ v_ns[1:15]
     @test values(ns)[1:15] ≈ v_ns[16:30] # repeated via FaceView in ns
 
-    # Planar QuadFace with colinear edge 
-    v = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(2.0,0.0,0.0),Point{3,Float64}(2.0,1.0,0.0)]
+    # Planar QuadFace with colinear edge
+    v = [Point3d(0,0,0),Point3d(1,0,0),Point3d(2,0,0),Point3d(2,1,0)]
     f = [QuadFace{Int}(1,2,3,4)]
     n = normals(v,f)
     @test all(n_i -> n_i ≈ [0.0,0.0,1.0], n)
 
-    # Planar NgonFace (5-sided) with colinear edge 
-    v = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(2.0,0.0,0.0),Point{3,Float64}(2.0,1.0,0.0),Point{3,Float64}(2.0,0.5,0.0)]
+    # Planar NgonFace (5-sided) with colinear edge
+    v = [Point3d(0,0,0),Point3d(1,0,0),Point3d(2,0,0),Point3d(2,1,0),Point3d(2,0.5,0)]
     f = [NgonFace{5,Int}(1,2,3,4,5)]
     n = normals(v,f)
     @test all(n_i -> n_i ≈ [0.0,0.0,1.0], n)
 
-    # Non-planar NgonFace (6 sided), features equal up and down variations resulting in z-dir average face_normal    
+    # Non-planar NgonFace (6 sided), features equal up and down variations resulting in z-dir average face_normal
     t = range(0.0,2*pi-(2*pi)/6,6)
     v = [Point{3,Float64}(cos(t[i]),sin(t[i]),iseven(i)) for i in eachindex(t)]
     f = [NgonFace{6,Int}(1,2,3,4,5,6)]

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -334,12 +334,28 @@ end
 
 @testset "orthogonal_vector" begin
     tri = Triangle(Point3d(0,0,0), Point3d(1,0,0), Point3d(0,1,0))
-    @test GeometryBasics.orthogonal_vector(tri) == Vec3d(0,0,1)
-    @test GeometryBasics.orthogonal_vector(collect(coordinates(tri))) == Vec3d(0,0,1)
+    @test GeometryBasics.orthogonal_vector(tri) === Vec3d(0,0,1)
+    @test GeometryBasics.orthogonal_vector(collect(coordinates(tri))) === Vec3d(0,0,1)
+    @test GeometryBasics.orthogonal_vector(Vec3f, tri) === Vec3f(0,0,1)
+    @test GeometryBasics.orthogonal_vector(Vec3f, collect(coordinates(tri))) === Vec3f(0,0,1)
 
     quad = GeometryBasics.Quadrilateral(Point2i(0,0), Point2i(1,0), Point2i(1,1), Point2i(0,1))
-    @test GeometryBasics.orthogonal_vector(quad) == Vec3i(0,0,2)
-    @test GeometryBasics.orthogonal_vector(collect(coordinates(quad))) == Vec3i(0,0,2)
+    @test GeometryBasics.orthogonal_vector(quad) === Vec3i(0,0,2)
+    @test GeometryBasics.orthogonal_vector(collect(coordinates(quad))) === Vec3i(0,0,2)
+    @test GeometryBasics.orthogonal_vector(Vec3d, quad) === Vec3d(0,0,2)
+    @test GeometryBasics.orthogonal_vector(Vec3d, collect(coordinates(quad))) === Vec3d(0,0,2)
+
+    t = (Point3f(0), Point3f(1,0,1), Point3f(0,1,0))
+    @test GeometryBasics.orthogonal_vector(t) == Vec3f(-1,0,1)
+    @test GeometryBasics.orthogonal_vector(Vec3i, t) == Vec3i(-1,0,1)#
+
+    # Maybe the ::Any fallback is too generic...?
+    struct TestType
+        data::Vector{Vec3f}
+    end
+    GeometryBasics.coordinates(x::TestType) = x.data
+    x = TestType([Point3f(1,1,1), Point3f(0,0,0), Point3f(0.5,0,0)])
+    @test GeometryBasics.orthogonal_vector(x) == Vec3f(0, -0.5, 0.5)
 end
 
 @testset "Normals" begin

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -381,7 +381,7 @@ end
     @test all(n_i -> n_i ≈ [0.0,0.0,1.0], n)
 
     # Non-planar NgonFace (6 sided), features equal up and down variations resulting in z-dir average face_normal
-    t = range(0.0,2*pi-(2*pi)/6,6)
+    t = range(0.0, 2*pi-(2*pi)/6, length = 6)
     v = [Point{3,Float64}(cos(t[i]),sin(t[i]),iseven(i)) for i in eachindex(t)]
     f = [NgonFace{6,Int}(1,2,3,4,5,6)]
     n = normals(v,f)


### PR DESCRIPTION
@ffreyer @SimonDanisch This PR implements the "shoelace" method for normal computation: 
![image](https://github.com/user-attachments/assets/c9f00190-cb9e-4ad2-bd69-21a32b8ab42f)

The approach should reduce to the same thing for triangles but generalises properly for faces with more than 3 vertices. Previously 3 points were taken along the face to compute the normal. This assumes that the face/polygon is planar and that the chosen points are not for co-linear edges. However both can naturally occur for faces with more than 3 nodes. Previously such faces would have inaccurate normals computed or NaNs would be returned. 

Here is a test case for a Quad with a co-linear edge, the above implemented method now returns the z-dir as the normal direction properly: 
```
v = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(2.0,0.0,0.0),Point{3,Float64}(2.0,1.0,0.0)]
f = [QuadFace{Int}(1,2,3,4)]
n = normals(v,f)
```
I have implemented other cases for testing too. Note that during testing for me this errored: 
``` 
    @test all(n -> n == values(ns)[end], values(f_ns)[16:end])
```
It seemed correct to withing 1e-8, So I changed it to use `≈`
```
    @test all(n -> n ≈ values(ns)[end], values(f_ns)[16:end])
```
Check if that is indeed what we'd like. 

Let me know if you are happy with this or if you need me to work on anything. 
