### PR TITLE
Fix float stability in orthogonal_vector

### DIFF
--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -148,25 +148,17 @@ expand to 3D space.
 
 Note that this vector is not normalized.
 """
-function orthogonal_vector(::Type{VT}, vertices) where {VT <: VecTypes{3}}
-    c = zeros(VT) # Inherit vector type from input
-    prev = to_ndim(VT, last(coordinates(vertices)), 0)
-    @inbounds for p in coordinates(vertices) # Use shoelace approach
-        v = to_ndim(VT, p, 0)
-        # cross(prev-v, v) is equivalent to cross(prev, v) but improves float precision
-        c += cross(prev - v, v) # Add each edge contribution
-        prev = v
-    end
-    return c
-end
+orthogonal_vector(::Type{VT}, vertices) where {VT <: VecTypes{3}} = _orthogonal_vector(VT, coordinates(vertices))
+orthogonal_vector(::Type{VT}, vertices::Tuple) where {VT <: VecTypes{3}} = _orthogonal_vector(VT, vertices)
 
-function orthogonal_vector(::Type{VT}, vertices::Tuple) where {VT <: VecTypes{3}}
-    c = zeros(VT) # Inherit vector type from input
-    prev = to_ndim(VT, last(vertices), 0)
-    @inbounds for p in vertices # Use shoelace approach
-        v = to_ndim(VT, p, 0)
-        # cross(prev-v, v) is equivalent to cross(prev, v) but improves float precision
-        c += cross(prev - v, v) # Add each edge contribution
+function _orthogonal_vector(::Type{VT}, vertices) where {VT <: VecTypes{3}}
+    c = zero(VT)
+    p0 = first(vertices)
+    prev = zero(VT)
+    for i in eachindex(vertices)
+        i == lastindex(vertices) && break
+        v = to_ndim(VT, vertices[i+1] - p0, 0)
+        c += cross(prev, v)
         prev = v
     end
     return c

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -153,7 +153,8 @@ function orthogonal_vector(::Type{VT}, vertices) where {VT <: VecTypes{3}}
     prev = to_ndim(VT, last(coordinates(vertices)), 0)
     @inbounds for p in coordinates(vertices) # Use shoelace approach
         v = to_ndim(VT, p, 0)
-        c += cross(prev, v) # Add each edge contribution
+        # cross(prev-v, v) is equivalent to cross(prev, v) but improves float precision
+        c += cross(prev - v, v) # Add each edge contribution
         prev = v
     end
     return c
@@ -164,7 +165,8 @@ function orthogonal_vector(::Type{VT}, vertices::Tuple) where {VT <: VecTypes{3}
     prev = to_ndim(VT, last(vertices), 0)
     @inbounds for p in vertices # Use shoelace approach
         v = to_ndim(VT, p, 0)
-        c += cross(prev, v) # Add each edge contribution
+        # cross(prev-v, v) is equivalent to cross(prev, v) but improves float precision
+        c += cross(prev - v, v) # Add each edge contribution
         prev = v
     end
     return c

--- a/src/geometry_primitives.jl
+++ b/src/geometry_primitives.jl
@@ -173,7 +173,7 @@ function orthogonal_vector(::Type{VT}, vertices::Tuple) where {VT <: VecTypes{3}
 end
 
 # Not sure how useful this fast path is, but it's simple to keep
-function orthogonal_vector(::Type{VT}, triangle::Triangle) where {VT <: VecTypes{3}}
+function orthogonal_vector(::Type{VT}, triangle::Union{Triangle, NTuple{3, <:VecTypes}, StaticVector{3, <:VecTypes}}) where {VT <: VecTypes{3}}
     a, b, c = triangle
     return cross(to_ndim(VT, b-a, 0), to_ndim(VT, c-a, 0))
 end

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -352,7 +352,10 @@ end
 
     t = (Point3f(0), Point3f(1,0,1), Point3f(0,1,0))
     @test GeometryBasics.orthogonal_vector(t) == Vec3f(-1,0,1)
-    @test GeometryBasics.orthogonal_vector(Vec3i, t) == Vec3i(-1,0,1)#
+    @test GeometryBasics.orthogonal_vector(Vec3i, t) == Vec3i(-1,0,1)
+
+    t = Point2f[(0,0), (1,0), (2,1), (1,2), (0,2), (-1, 1)]
+    @test GeometryBasics.orthogonal_vector(Vec3f, t) == Vec3f(0,0,8)
 
     # Maybe the ::Any fallback is too generic...?
     struct TestType


### PR DESCRIPTION
Fixes #251

Switched the generic `orthogonal_vector` to
```math
\sum_i (q_i - q_1) \times (q_{i+1} - q_1)
= \sum_i q_i \times q_{i+1} - q_0 \times q_{i+1} - q_i \times q_0
```
which is equivalent to the previous formula as the last two terms cancel. (Swapping the order of cross product inputs introduces a - which allows one term to cancel the other over the full summation.) (The summation skips the last iteration as q_i+1 - q_1 = q_1 - q_1 doesn't contribute.)

Also extended the types for the fast path so it's hit by default for triangle meshes again

All the failing triangles from #251 removed subtractions from the cross product. I added a few of these as tests, as well as one which doesn't remove subtractions. I also added another sanity check for faces with more than 4 vertices (verified on master) as I was getting confused about what length to expect.
