### PR TITLE
Add Cone primitive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       JULIA_PKG_SERVER: ""
     steps:

--- a/docs/src/primitives.md
+++ b/docs/src/primitives.md
@@ -9,7 +9,7 @@ GeometryBasics comes with a few predefined primitives:
 
 #### HyperRectangle
 
-A `Rect{D, T} = HyperRectangle{D, T}` is a D-dimensional axis-aligned 
+A `Rect{D, T} = HyperRectangle{D, T}` is a D-dimensional axis-aligned
 hyperrectangle defined by an origin and a size.
 
 ```@repl rects
@@ -33,7 +33,7 @@ Shorthands:
 
 #### Sphere and Circle
 
-`Circle` and `Sphere` are the 2 and 3 dimensional variants of `HyperSphere`. 
+`Circle` and `Sphere` are the 2 and 3 dimensional variants of `HyperSphere`.
 They are defined by an origin and a radius.
 While you can technically create a HyperSphere of any dimension, decomposition
 is only defined in 2D and 3D.
@@ -54,7 +54,6 @@ The coordinates of Circle are defined in anti-clockwise order.
 
 A `Cylinder` is a 3D shape defined by two points and a radius.
 
-
 ```@setup cylinder
 using GeometryBasics
 ```
@@ -64,12 +63,24 @@ c = Cylinder(Point3f(-1, 0, 0), Point3f(0, 0, 1), 0.3f0) # start point, end poin
 
 Cylinder supports normals an Tessellation, but currently no texture coordinates.
 
+#### Cone
+
+A `Cone` is also defined by two points and a radius, but the radius decreases to 0 from the start point to the tip.
+
+```@setup cone
+using GeometryBasics
+```
+```@repl cone
+c = Cone(Point3f(-1, 0, 0), Point3f(0, 0, 1), 0.3f0) # start point, tip point, radius
+```
+
+Cone supports normals an Tessellation, but currently no texture coordinates.
+
 #### Pyramid
 
 `Pyramid` corresponds to a pyramid shape with a square base and four triangles
 coming together into a sharp point.
 It is defined by by the center point of the base, its height and its width.
-
 
 ```@setup pyramid
 using GeometryBasics
@@ -132,7 +143,7 @@ end
 ```
 
 To connect these points into a mesh, we need to generate a set of faces.
-The faces of a parallelepiped are parallelograms, which we can describe with `QuadFace`. 
+The faces of a parallelepiped are parallelograms, which we can describe with `QuadFace`.
 Here we should be conscious of the winding direction of faces.
 They are often used to determine the front vs the backside of a (2D) face.
 For example GeometryBasics normal generation and OpenGL's backface culling assume a counter-clockwise winding direction to correspond to a front-facing face.
@@ -187,7 +198,7 @@ function GeometryBasics.texturecoordinates(::Parallelepiped{T}) where {T}
     uvs = [Vec2f(x, y) for x in range(0, 1, length=4) for y in range(0, 1, 3)]
     fs = QuadFace{Int}[
         (1, 2, 5, 4),   (2, 3, 6, 5),
-        (4, 5, 8, 7),   (5, 6, 9, 8), 
+        (4, 5, 8, 7),   (5, 6, 9, 8),
         (7, 8, 11, 10), (8, 9, 12, 11)
     ]
     return FaceView(uvs, fs)

--- a/docs/src/primitives.md
+++ b/docs/src/primitives.md
@@ -61,7 +61,7 @@ using GeometryBasics
 c = Cylinder(Point3f(-1, 0, 0), Point3f(0, 0, 1), 0.3f0) # start point, end point, radius
 ```
 
-Cylinder supports normals an Tessellation, but currently no texture coordinates.
+Cylinder supports normals and Tessellation, but currently no texture coordinates.
 
 #### Cone
 
@@ -74,7 +74,7 @@ using GeometryBasics
 c = Cone(Point3f(-1, 0, 0), Point3f(0, 0, 1), 0.3f0) # start point, tip point, radius
 ```
 
-Cone supports normals an Tessellation, but currently no texture coordinates.
+Cone supports normals and Tessellation, but currently no texture coordinates.
 
 #### Pyramid
 

--- a/src/GeometryBasics.jl
+++ b/src/GeometryBasics.jl
@@ -17,6 +17,7 @@ include("primitives/spheres.jl")
 include("primitives/cylinders.jl")
 include("primitives/pyramids.jl")
 include("primitives/particles.jl")
+include("primitives/Cone.jl")
 
 include("interfaces.jl")
 include("viewtypes.jl")
@@ -56,7 +57,7 @@ export triangle_mesh, triangle_mesh, uv_mesh
 export uv_mesh, normal_mesh, uv_normal_mesh
 
 export height, origin, radius, width, widths
-export HyperSphere, Circle, Sphere
+export HyperSphere, Circle, Sphere, Cone
 export Cylinder, Pyramid, extremity
 export HyperRectangle, Rect, Rect2, Rect3, Recti, Rect2i, Rect3i, Rectf, Rect2f, Rect3f, Rectd, Rect2d, Rect3d, RectT
 export before, during, meets, overlaps, intersects, finishes

--- a/src/primitives/Cone.jl
+++ b/src/primitives/Cone.jl
@@ -79,7 +79,19 @@ function normals(c::Cone, nvertices = 30)
     # cap
     ns[end] = Vec3f(normalize(c.origin - c.tip))
 
-    return ns
+    faces = Vector{GLTriangleFace}(undef, nvertices)
+
+    # shell
+    for i in 1:nhalf
+        faces[i] = GLTriangleFace(i, mod1(i+1, nhalf), nhalf+1)
+    end
+
+    # cap
+    for i in 1:nhalf
+        faces[i+nhalf] = GLTriangleFace(nhalf + 2)
+    end
+
+    return FaceView(ns, faces)
 end
 
 function faces(::Cone, facets=30)

--- a/src/primitives/Cone.jl
+++ b/src/primitives/Cone.jl
@@ -21,25 +21,11 @@ radius(c::Cone) = c.radius
 height(c::Cone) = norm(c.tip - c.origin)
 direction(c::Cone) = (c.tip .- c.origin) ./ height(c)
 
-function rotation(c::Cone{T}) where {T}
-    d3 = direction(c)
-    u = Vec{3, T}(d3[1], d3[2], d3[3])
-    if abs(u[1]) > 0 || abs(u[2]) > 0
-        v = Vec{3, T}(u[2], -u[1], T(0))
-    else
-        v = Vec{3, T}(T(0), -u[3], u[2])
-    end
-    v = normalize(v)
-    w = Vec{3, T}(u[2] * v[3] - u[3] * v[2], -u[1] * v[3] + u[3] * v[1],
-                  u[1] * v[2] - u[2] * v[1])
-    return Mat{3, 3, T}(v..., w..., u...)
-end
-
 function coordinates(c::Cone{T}, nvertices=30) where {T}
     nvertices += isodd(nvertices)
     nhalf = div(nvertices, 2)
 
-    R = rotation(c)
+    R = cylinder_rotation_matrix(direction(c))
     step = 2pi / nhalf
 
     ps = Vector{Point3{T}}(undef, nhalf + 2)
@@ -57,7 +43,7 @@ function normals(c::Cone, nvertices = 30)
     nvertices += isodd(nvertices)
     nhalf = div(nvertices, 2)
 
-    R = rotation(c)
+    R = cylinder_rotation_matrix(direction(c))
     step = 2pi / nhalf
 
     ns = Vector{Vec3f}(undef, nhalf + 2)

--- a/src/primitives/Cone.jl
+++ b/src/primitives/Cone.jl
@@ -21,6 +21,11 @@ radius(c::Cone) = c.radius
 height(c::Cone) = norm(c.tip - c.origin)
 direction(c::Cone) = (c.tip .- c.origin) ./ height(c)
 
+# Note:
+# nvertices is matched with Cylinder, where each end has half the vertices. That
+# results in less than nvertices for Cone, but allows a Cylinder and a Cone to
+# be seamless matched with the same `nvertices`
+
 function coordinates(c::Cone{T}, nvertices=30) where {T}
     nvertices += isodd(nvertices)
     nhalf = div(nvertices, 2)

--- a/src/primitives/Cone.jl
+++ b/src/primitives/Cone.jl
@@ -1,0 +1,102 @@
+"""
+    Cone{T}(origin::Point3, tip::Point3, radius)
+
+A Cone is a cylinder where one end has a radius of 0. It is defined by an
+`origin` with a finite `radius` which linearly decreases to 0 at the `tip`.
+"""
+struct Cone{T} <: GeometryPrimitive{3, T}
+    origin::Point3{T}
+    tip::Point3{T}
+    radius::T
+end
+
+function Cone(origin::Point3{T1}, tip::Point3{T2}, radius::T3) where {T1, T2, T3}
+    T = promote_type(T1, T2, T3)
+    return Cone{T}(origin, tip, radius)
+end
+
+origin(c::Cone) = c.origin
+extremity(c::Cone) = c.tip
+radius(c::Cone) = c.radius
+height(c::Cone) = norm(c.tip - c.origin)
+direction(c::Cone) = (c.tip .- c.origin) ./ height(c)
+
+function rotation(c::Cone{T}) where {T}
+    d3 = direction(c)
+    u = Vec{3, T}(d3[1], d3[2], d3[3])
+    if abs(u[1]) > 0 || abs(u[2]) > 0
+        v = Vec{3, T}(u[2], -u[1], T(0))
+    else
+        v = Vec{3, T}(T(0), -u[3], u[2])
+    end
+    v = normalize(v)
+    w = Vec{3, T}(u[2] * v[3] - u[3] * v[2], -u[1] * v[3] + u[3] * v[1],
+                  u[1] * v[2] - u[2] * v[1])
+    return Mat{3, 3, T}(v..., w..., u...)
+end
+
+function coordinates(c::Cone{T}, nvertices=30) where {T}
+    nvertices += isodd(nvertices)
+    nhalf = div(nvertices, 2)
+
+    R = rotation(c)
+    step = 2pi / nhalf
+
+    ps = Vector{Point3{T}}(undef, nhalf + 2)
+    for i in 1:nhalf
+        phi = (i-1) * step
+        ps[i] = R * Point3{T}(c.radius * cos(phi), c.radius * sin(phi), 0) + c.origin
+    end
+    ps[end-1] = c.tip
+    ps[end] = c.origin
+
+    return ps
+end
+
+function normals(c::Cone, nvertices = 30)
+    nvertices += isodd(nvertices)
+    nhalf = div(nvertices, 2)
+
+    R = rotation(c)
+    step = 2pi / nhalf
+
+    ns = Vector{Vec3f}(undef, nhalf + 2)
+    # shell at origin
+    # normals are angled in z direction due to change in radius (from radius to 0)
+    # This can be calculated from triangles
+    z = radius(c) / height(c)
+    norm = 1.0 / sqrt(1 + z*z)
+    for i in 1:nhalf
+        phi = (i-1) * step
+        ns[i] = R * (norm * Vec3f(cos(phi), sin(phi), z))
+    end
+
+    # tip - this is undefined / should be all ring angles at once
+    # for rendering it is useful to define this as Vec3f(0), because tip normal
+    # has no useful value to contribute to the interpolated fragment normal
+    ns[end-1] = Vec3f(0)
+
+    # cap
+    ns[end] = Vec3f(normalize(c.origin - c.tip))
+
+    return ns
+end
+
+function faces(::Cone, facets=30)
+    nvertices = facets + isodd(facets)
+    nhalf = div(nvertices, 2)
+
+    faces = Vector{GLTriangleFace}(undef, nvertices)
+
+    # shell
+    for i in 1:nhalf
+        faces[i] = GLTriangleFace(i, mod1(i+1, nhalf), nhalf+1)
+    end
+
+    # cap
+    for i in 1:nhalf
+        faces[i+nhalf] = GLTriangleFace(i, mod1(i+1, nhalf), nhalf+2)
+    end
+
+    return faces
+end

--- a/src/primitives/cylinders.jl
+++ b/src/primitives/cylinders.jl
@@ -21,8 +21,15 @@ radius(c::Cylinder) = c.r
 height(c::Cylinder) = norm(c.extremity - c.origin)
 direction(c::Cylinder) = (c.extremity .- c.origin) ./ height(c)
 
-function rotation(c::Cylinder{T}) where {T}
-    d3 = direction(c)
+"""
+    cylinder_rotation_matrix(direction::VecTypes{3})
+
+Creates a basis transformation matrix `R` that maps the third dimension to the
+given `direction` and the first and second to orthogonal directions. This allows
+you to encode a rotation around `direction` in the first two components and
+transform it with `R * rotated_point`.
+"""
+function cylinder_rotation_matrix(d3::VecTypes{3, T}) where {T}
     u = Vec{3, T}(d3[1], d3[2], d3[3])
     if abs(u[1]) > 0 || abs(u[2]) > 0
         v = Vec{3, T}(u[2], -u[1], T(0))
@@ -39,9 +46,9 @@ function coordinates(c::Cylinder{T}, nvertices=30) where {T}
     nvertices += isodd(nvertices)
     nhalf = div(nvertices, 2)
 
-    R = rotation(c)
+    R = cylinder_rotation_matrix(direction(c))
     step = 2pi / nhalf
-    
+
     ps = Vector{Point3{T}}(undef, nvertices + 2)
     for i in 1:nhalf
         phi = (i-1) * step
@@ -61,9 +68,9 @@ function normals(c::Cylinder, nvertices = 30)
     nvertices += isodd(nvertices)
     nhalf = div(nvertices, 2)
 
-    R = rotation(c)
+    R = cylinder_rotation_matrix(direction(c))
     step = 2pi / nhalf
-    
+
     ns = Vector{Vec3f}(undef, nhalf + 2)
     for i in 1:nhalf
         phi = (i-1) * step

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -752,8 +752,12 @@ end
             (0.0, 0.0, 0.0),
             (-0.57735026, -0.57735026, -0.57735026),
         ]
+        fs = [
+            GLTriangleFace(1, 2, 5), GLTriangleFace(2, 3, 5), GLTriangleFace(3, 4, 5), GLTriangleFace(4, 1, 5),
+            GLTriangleFace(6, 6, 6), GLTriangleFace(6, 6, 6), GLTriangleFace(6, 6, 6), GLTriangleFace(6, 6, 6)
+        ]
 
-        @test ns == decompose_normals(Tessellation(s, 8))
+        @test FaceView(ns, fs) == decompose_normals(Tessellation(s, 8))
 
         muv = uv_mesh(s)
         @test !hasproperty(muv, :uv) # not defined yet


### PR DESCRIPTION
I want to remove the mesh generation code in Makie that's used for arrows and add replacements as GeometryPrimitives here. This is coupled with https://github.com/MakieOrg/Makie.jl/pull/4925.

Currently this just adds `Cone()` with the idea of simplifying the arrow components to full, closed meshes. 