### PR TITLE
GeoInterface improvements

### DIFF
--- a/ext/GeometryBasicsGeoInterfaceExt.jl
+++ b/ext/GeometryBasicsGeoInterfaceExt.jl
@@ -34,6 +34,7 @@ geointerface_geomtype(::GeoInterface.PointTrait) = Point
 geointerface_geomtype(::GeoInterface.MultiPointTrait) = MultiPoint
 geointerface_geomtype(::GeoInterface.LineTrait) = Line
 geointerface_geomtype(::GeoInterface.LineStringTrait) = LineString
+geointerface_geomtype(::GeoInterface.LinearRingTrait) = LineString
 geointerface_geomtype(::GeoInterface.MultiLineStringTrait) = MultiLineString
 geointerface_geomtype(::GeoInterface.PolygonTrait) = Polygon
 geointerface_geomtype(::GeoInterface.MultiPolygonTrait) = MultiPolygon
@@ -111,7 +112,7 @@ function GeoInterface.convert(::Type{Point}, type::PointTrait, geom)
         return Point{2,T}(x, y)
     end
 end
-function GeoInterface.convert(::Type{LineString}, type::LineStringTrait, geom)
+function GeoInterface.convert(::Type{LineString}, type::Union{LineStringTrait, LinearRingTrait}, geom)
     g1 = getgeom(geom, 1)
     x, y = GeoInterface.x(g1), GeoInterface.y(g1)
     if GeoInterface.is3d(geom)

--- a/ext/GeometryBasicsGeoInterfaceExt.jl
+++ b/ext/GeometryBasicsGeoInterfaceExt.jl
@@ -112,6 +112,18 @@ function GeoInterface.convert(::Type{Point}, type::PointTrait, geom)
         return Point{2,T}(x, y)
     end
 end
+function GeoInterface.convert(::Type{Line}, type::LineTrait, geom)
+    g1, g2 = GeoInterface.getgeom(geom)
+    x, y = GeoInterface.x(g1), GeoInterface.y(g1)
+    if GeoInterface.is3d(geom)
+        z = GeoInterface.z(g1)
+        T = promote_type(typeof(x), typeof(y), typeof(z))
+        return Line{3,T}(Point{3,T}(x, y, z), Point{3,T}(GeoInterface.x(g2), GeoInterface.y(g2), GeoInterface.z(g2)))
+    else
+        T = promote_type(typeof(x), typeof(y))
+        return Line{2,T}(Point{2,T}(x, y), Point{2,T}(GeoInterface.x(g2), GeoInterface.y(g2)))
+    end
+end
 function GeoInterface.convert(::Type{LineString}, type::Union{LineStringTrait, LinearRingTrait}, geom)
     g1 = getgeom(geom, 1)
     x, y = GeoInterface.x(g1), GeoInterface.y(g1)

--- a/test/geointerface.jl
+++ b/test/geointerface.jl
@@ -210,3 +210,31 @@ end
     @test mls isa MultiLineString{2, Float64}
     @test length(mls) == 2
 end
+
+@testset "Convert Line and LinearRing" begin
+    # Line (2D)
+    gi_line_2d = GeoInterface.Line([(1.0, 2.0), (3.0, 4.0)])
+    line_2d = GeoInterface.convert(GeometryBasics, gi_line_2d)
+    @test line_2d isa Line{2, Float64}
+    @test line_2d[1] == Point(1.0, 2.0)
+    @test line_2d[2] == Point(3.0, 4.0)
+
+    # Line (3D)
+    gi_line_3d = GeoInterface.Line([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)])
+    line_3d = GeoInterface.convert(GeometryBasics, gi_line_3d)
+    @test line_3d isa Line{3, Float64}
+    @test line_3d[1] == Point(1.0, 2.0, 3.0)
+    @test line_3d[2] == Point(4.0, 5.0, 6.0)
+
+    # LinearRing → LineString (2D)
+    gi_ring = GeoInterface.LinearRing([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)])
+    ls_from_ring = GeoInterface.convert(GeometryBasics, gi_ring)
+    @test ls_from_ring isa LineString{2, Float64}
+    @test length(ls_from_ring) == 4
+
+    # LinearRing → LineString (3D)
+    gi_ring_3d = GeoInterface.LinearRing([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 0.0, 0.0)])
+    ls_from_ring_3d = GeoInterface.convert(GeometryBasics, gi_ring_3d)
+    @test ls_from_ring_3d isa LineString{3, Float64}
+    @test length(ls_from_ring_3d) == 4
+end


### PR DESCRIPTION
## Summary

- Adds `GeoInterface.convert` for `LineTrait` → `GeometryBasics.Line` (2D and 3D)
- Extends `GeoInterface.convert` for `LineString` to also accept `LinearRingTrait`, so converting any `Polygon` (which has `LinearRing` exterior/holes) works correctly
- Adds `geointerface_geomtype(::LinearRingTrait) = LineString`
- Adds tests covering all new code paths (2D and 3D `Line` conversion, 2D and 3D `LinearRing` → `LineString` conversion)