### PR TITLE
Add tests for GeoInterface.coordtype and fix method ambiguity

### DIFF
--- a/ext/GeometryBasicsGeoInterfaceExt.jl
+++ b/ext/GeometryBasicsGeoInterfaceExt.jl
@@ -160,11 +160,29 @@ function _collect_with_type(::Type{PT}, geom) where {PT <: Point{2}}
 end
 
 # coordtype implementation - GeometryBasics encodes coordinate type in eltype
+# Use specific traits to avoid method ambiguity with GeoInterface fallbacks
 if isdefined(GeoInterface, :coordtype)
-    # For types with coordinate type T as a type parameter
-    GeoInterface.coordtype(::GeoInterface.AbstractGeometryTrait, geom::Point{Dim,T}) where {Dim,T} = T
-    GeoInterface.coordtype(::GeoInterface.AbstractGeometryTrait, geom::AbstractGeometry{Dim,T}) where {Dim,T} = T
-    GeoInterface.coordtype(::GeoInterface.AbstractGeometryTrait, geom::Simplex{Dim,T,N}) where {Dim,T,N} = T
+    # Point
+    GeoInterface.coordtype(::GeoInterface.PointTrait, geom::Point{Dim,T}) where {Dim,T} = T
+    # Line
+    GeoInterface.coordtype(::GeoInterface.LineTrait, geom::Line{Dim,T}) where {Dim,T} = T
+    # LineString
+    GeoInterface.coordtype(::GeoInterface.LineStringTrait, geom::LineString{Dim,T}) where {Dim,T} = T
+    # Polygon
+    GeoInterface.coordtype(::GeoInterface.PolygonTrait, geom::Polygon{Dim,T}) where {Dim,T} = T
+    # MultiPoint
+    GeoInterface.coordtype(::GeoInterface.MultiPointTrait, geom::MultiPoint{Dim,T}) where {Dim,T} = T
+    # MultiLineString
+    GeoInterface.coordtype(::GeoInterface.MultiLineStringTrait, geom::MultiLineString{Dim,T}) where {Dim,T} = T
+    # MultiPolygon
+    GeoInterface.coordtype(::GeoInterface.MultiPolygonTrait, geom::MultiPolygon{Dim,T}) where {Dim,T} = T
+    # Ngon (uses PolygonTrait)
+    GeoInterface.coordtype(::GeoInterface.PolygonTrait, geom::Ngon{Dim,T,N}) where {Dim,T,N} = T
+    # Simplex (can have PointTrait, LineStringTrait, or PolygonTrait depending on N)
+    GeoInterface.coordtype(::GeoInterface.PointTrait, geom::Simplex{Dim,T,1}) where {Dim,T} = T
+    GeoInterface.coordtype(::GeoInterface.LineStringTrait, geom::Simplex{Dim,T,2}) where {Dim,T} = T
+    GeoInterface.coordtype(::GeoInterface.PolygonTrait, geom::Simplex{Dim,T,3}) where {Dim,T} = T
+    # Mesh
     GeoInterface.coordtype(::GeoInterface.PolyhedralSurfaceTrait, geom::Mesh{Dim,T,E,V}) where {Dim,T,E,V} = T
 end
 

--- a/test/geointerface.jl
+++ b/test/geointerface.jl
@@ -129,3 +129,61 @@ end
     @test ext.Y == (0.0f0, 1.0f0)
     @test ext.Z == (0.0f0, 1.0f0)
 end
+
+@testset "coordtype" begin
+    if isdefined(GeoInterface, :coordtype)
+        # Point
+        point_int = Point(2, 3)
+        point_float = Point(2.0, 3.0)
+        point_float32 = Point{2,Float32}(2.0, 3.0)
+        point_3d = Point{3,Float64}(1.0, 2.0, 3.0)
+        @test GeoInterface.coordtype(point_int) == Int
+        @test GeoInterface.coordtype(point_float) == Float64
+        @test GeoInterface.coordtype(point_float32) == Float32
+        @test GeoInterface.coordtype(point_3d) == Float64
+
+        # Line (AbstractGeometry)
+        line = Line(Point(2, 3), Point(4, 5))
+        line_float = Line(Point(2.0, 3.0), Point(4.0, 5.0))
+        @test GeoInterface.coordtype(line) == Int
+        @test GeoInterface.coordtype(line_float) == Float64
+
+        # LineString
+        linestring = LineString(Point{2,Int}[(10, 10), (20, 20), (10, 40)])
+        linestring_float = LineString(Point{2,Float64}[(10.0, 10.0), (20.0, 20.0)])
+        @test GeoInterface.coordtype(linestring) == Int
+        @test GeoInterface.coordtype(linestring_float) == Float64
+
+        # MultiPoint
+        mp = MultiPoint([Point(2, 3), Point(4, 5)])
+        mp_float = MultiPoint([Point(2.0, 3.0), Point(4.0, 5.0)])
+        @test GeoInterface.coordtype(mp) == Int
+        @test GeoInterface.coordtype(mp_float) == Float64
+
+        # MultiLineString
+        mls = MultiLineString([linestring, linestring])
+        mls_float = MultiLineString([linestring_float, linestring_float])
+        @test GeoInterface.coordtype(mls) == Int
+        @test GeoInterface.coordtype(mls_float) == Float64
+
+        # Polygon
+        poly_float32 = Polygon(rand(Point{2,Float32}, 5))
+        poly_float64 = Polygon(rand(Point{2,Float64}, 5))
+        @test GeoInterface.coordtype(poly_float32) == Float32
+        @test GeoInterface.coordtype(poly_float64) == Float64
+
+        # MultiPolygon
+        mpoly = MultiPolygon([poly_float32, poly_float32])
+        @test GeoInterface.coordtype(mpoly) == Float32
+
+        # Simplex (Triangle is Ngon which is a Simplex)
+        triangle = Triangle(Point(1, 2), Point(3, 4), Point(5, 6))
+        triangle_float = Triangle(Point(1.0, 2.0), Point(3.0, 4.0), Point(5.0, 6.0))
+        @test GeoInterface.coordtype(triangle) == Int
+        @test GeoInterface.coordtype(triangle_float) == Float64
+
+        # Mesh
+        mesh = triangle_mesh(Sphere(Point3f(0), 1))
+        @test GeoInterface.coordtype(mesh) == Float32
+    end
+end


### PR DESCRIPTION
## Summary
- Add comprehensive tests for `GeoInterface.coordtype` covering all geometry types: Point, Line, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, Triangle (Ngon), and Mesh
- Tests cover different coordinate types (Int, Float32, Float64) and dimensions (2D, 3D)
- Fix method ambiguity in coordtype implementation by using specific GeoInterface traits instead of `AbstractGeometryTrait`, which was conflicting with GeoInterface's fallback methods

## Test plan
- [x] All existing tests pass
- [x] New coordtype tests pass for all geometry types

🤖 Generated with [Claude Code](https://claude.com/claude-code)