### PR TITLE
add `coordinates` for `Rect1`

### DIFF
--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -532,8 +532,6 @@ function coordinates(rect::Rect{1, T}) where {T}
     return [Point{1,T}(o[1]), Point{1,T}(o[1]+w[1])]
 end
 
-texturecoordinates(rect::Rect{1}) = [Point{1,Int}(0), Point{1,Int}(1)]
-
 ##
 # Rect2 decomposition
 

--- a/src/primitives/rectangles.jl
+++ b/src/primitives/rectangles.jl
@@ -525,6 +525,16 @@ function Base.isapprox(r1::Rect, r2::Rect; kwargs...)
 end
 
 ##
+# Rect1 decomposition
+function coordinates(rect::Rect{1, T}) where {T}
+    w = widths(rect)
+    o = origin(rect)
+    return [Point{1,T}(o[1]), Point{1,T}(o[1]+w[1])]
+end
+
+texturecoordinates(rect::Rect{1}) = [Point{1,Int}(0), Point{1,Int}(1)]
+
+##
 # Rect2 decomposition
 
 function faces(rect::Rect2, nvertices=(2, 2))

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -672,12 +672,12 @@ end
     r = Rect{1,Float32}(0.2, 0.5)
     @test eltype(coordinates(r)) == Point{1,Float32}
     @test coordinates(r) == [Point{1,Float32}(0.2), Point{1,Float32}(0.7)]
-    @test texturecoordinates(r) == [Point{1,Int}(1), Point{1,Int}(1)]
+    @test texturecoordinates(r) == [Point{1,Int}(0), Point{1,Int}(1)]
 
     r64 = Rect{1,Float64}(-0.2, 1.3)
     @test eltype(coordinates(r64)) == Point{1,Float64}
     @test coordinates(r64) == [Point{1,Float64}(-0.2), Point{1,Float64}(1.1)]
-    @test texturecoordinates(r64) == [Point{1,Int}(1), Point{1,Int}(1)]
+    @test texturecoordinates(r64) == [Point{1,Int}(0), Point{1,Int}(1)]
 end
 
 @testset "LineStrings" begin

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -668,6 +668,16 @@ end
     r = Rect2i(2, 4, 2, 4)
     @test M[r] == [53 63 73 83; 54 64 74 84]
 
+    # Rect1 coordinates/texturecoordinates
+    r = Rect{1,Float32}(0.2, 0.5)
+    @test eltype(coordinates(r)) == Point{1,Float32}
+    @test coordinates(r) == [Point{1,Float32}(0.2), Point{1,Float32}(0.7)]
+    @test texturecoordinates(r) == [Point{1,Int}(1), Point{1,Int}(1)]
+
+    r64 = Rect{1,Float64}(-0.2, 1.3)
+    @test eltype(coordinates(r64)) == Point{1,Float64}
+    @test coordinates(r64) == [Point{1,Float64}(-0.2), Point{1,Float64}(1.1)]
+    @test texturecoordinates(r64) == [Point{1,Int}(1), Point{1,Int}(1)]
 end
 
 @testset "LineStrings" begin

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -687,12 +687,10 @@ end
     r = Rect{1,Float32}(0.2, 0.5)
     @test eltype(coordinates(r)) == Point{1,Float32}
     @test coordinates(r) == [Point{1,Float32}(0.2), Point{1,Float32}(0.7)]
-    @test texturecoordinates(r) == [Point{1,Int}(0), Point{1,Int}(1)]
 
     r64 = Rect{1,Float64}(-0.2, 1.3)
     @test eltype(coordinates(r64)) == Point{1,Float64}
     @test coordinates(r64) == [Point{1,Float64}(-0.2), Point{1,Float64}(1.1)]
-    @test texturecoordinates(r64) == [Point{1,Int}(0), Point{1,Int}(1)]
 end
 
 @testset "LineStrings" begin


### PR DESCRIPTION
I have wanted to use the `Rect` class here occasionally in some more generic contexts, and the absence of a `coordinates` method for the 1D case has then been a bit annoying: this just proposes adding it (and adds `texturecoordinates` alongside).

There is of course more that could be done for fleshing out the `Rect{1}` methods - and for `Rect{N}` interfaces more broadly, but my ambition is limited to just this.