### PR TITLE
Less method invalidations for OffsetInteger

### DIFF
--- a/src/offsetintegers.jl
+++ b/src/offsetintegers.jl
@@ -67,16 +67,34 @@ for op in (:(+), :(-), :(*), :(/), :div)
     end
 end
 
-for op in (:(==), :(>=), :(<=), :(<), :(>), :sub_with_overflow)
+# No mixed OffsetInteger/Integer methods for the comparison operators: they
+# go through Base's promotion machinery (promote_rule + convert above) with
+# identical semantics, just like mixed +/-/* already do. Defining e.g.
+# `==(::Integer, ::OffsetInteger)` invalidates compiled comparison code in
+# unrelated packages whenever GeometryBasics loads (~1.8k method instances,
+# measured via SnoopCompile in a Makie session).
+for op in (:(==), :(>=), :(<=), :(<), :(>))
     @eval begin
         function Base.$op(x::OffsetInteger{O}, y::OffsetInteger{O}) where {O}
             return $op(x.i, y.i)
         end
         Base.$op(x::OffsetInteger, y::OffsetInteger) = $op(value(x), value(y))
-        Base.$op(x::OffsetInteger, y::Integer) = $op(value(x), y)
-        Base.$op(x::Integer, y::OffsetInteger) = $op(x, value(y))
     end
 end
+
+# sub_with_overflow has no promoting `(::Integer, ::Integer)` fallback in
+# Base, so the mixed methods must stay. (The bodies must be qualified: the
+# old `$op(...)` interpolation produced an unqualified `sub_with_overflow`
+# call that never resolved in this module, so these methods used to throw
+# an UndefVarError when called.)
+function Base.Checked.sub_with_overflow(x::OffsetInteger{O}, y::OffsetInteger{O}) where {O}
+    return Base.Checked.sub_with_overflow(x.i, y.i)
+end
+function Base.Checked.sub_with_overflow(x::OffsetInteger, y::OffsetInteger)
+    return Base.Checked.sub_with_overflow(value(x), value(y))
+end
+Base.Checked.sub_with_overflow(x::OffsetInteger, y::Integer) = Base.Checked.sub_with_overflow(value(x), y)
+Base.Checked.sub_with_overflow(x::Integer, y::OffsetInteger) = Base.Checked.sub_with_overflow(x, value(y))
 
 Base.promote_rule(::Type{IT}, ::Type{<:OffsetInteger}) where {IT<:Integer} = IT
 

--- a/src/offsetintegers.jl
+++ b/src/offsetintegers.jl
@@ -82,20 +82,6 @@ for op in (:(==), :(>=), :(<=), :(<), :(>))
     end
 end
 
-# sub_with_overflow has no promoting `(::Integer, ::Integer)` fallback in
-# Base, so the mixed methods must stay. (The bodies must be qualified: the
-# old `$op(...)` interpolation produced an unqualified `sub_with_overflow`
-# call that never resolved in this module, so these methods used to throw
-# an UndefVarError when called.)
-function Base.Checked.sub_with_overflow(x::OffsetInteger{O}, y::OffsetInteger{O}) where {O}
-    return Base.Checked.sub_with_overflow(x.i, y.i)
-end
-function Base.Checked.sub_with_overflow(x::OffsetInteger, y::OffsetInteger)
-    return Base.Checked.sub_with_overflow(value(x), value(y))
-end
-Base.Checked.sub_with_overflow(x::OffsetInteger, y::Integer) = Base.Checked.sub_with_overflow(value(x), y)
-Base.Checked.sub_with_overflow(x::Integer, y::OffsetInteger) = Base.Checked.sub_with_overflow(x, value(y))
-
 Base.promote_rule(::Type{IT}, ::Type{<:OffsetInteger}) where {IT<:Integer} = IT
 
 function Base.promote_rule(::Type{OffsetInteger{O1,T1}},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -338,6 +338,45 @@ end
             @test <(x, x1)
         end
     end
+
+    # With a nonzero offset `raw != value`, so this exercises the arithmetic
+    # and the same-offset comparison method `op(x.i, y.i)` for an offset != 0.
+    let O = 3
+        a = OffsetInteger{O}(2)
+        b = OffsetInteger{O}(4)
+        @test GeometryBasics.value(a) == 2
+        @test GeometryBasics.raw(a) == 2 + O
+        @test Base.to_index(a) == 2
+        @test -(a)   == OffsetInteger{O}(-2)
+        @test abs(OffsetInteger{O}(-2)) == OffsetInteger{O}(2)
+        @test +(a, b)  == OffsetInteger{O}(6)
+        @test -(b, a)  == OffsetInteger{O}(2)
+        @test *(a, b)  == OffsetInteger{O}(8)
+        @test div(b, a) == OffsetInteger{O}(2)
+        @test a == OffsetInteger{O}(2)
+        @test a != b
+        @test a < b
+        @test a <= b
+        @test b > a
+        @test b >= a
+    end
+
+    # Comparing OffsetIntegers with *different* offsets goes through the
+    # value-based fallback method `op(value(x), value(y))`.
+    let
+        a = OffsetInteger{0}(5)  # value 5
+        b = OffsetInteger{3}(5)  # value 5
+        c = OffsetInteger{3}(7)  # value 7
+        @test a == b
+        @test a <= b
+        @test a >= b
+        @test !(a < b)
+        @test a < c
+        @test a <= c
+        @test c > a
+        @test c >= a
+        @test a != c
+    end
 end
 
 @testset "Tests from GeometryTypes" begin


### PR DESCRIPTION
Back in the day, I didn't have enough time to figure out why OffsetIntegers invalidate so many methods and how to fix it. The answer is, just let promotion do the hard work, and dont define unused methods :D 
