### PR TITLE
Make sphere and circle seam vertices bit-exact

### DIFF
--- a/src/primitives/spheres.jl
+++ b/src/primitives/spheres.jl
@@ -42,7 +42,7 @@ centered(S::Type{<: HyperSphere}) = S(Point3f(0), 0.5f0)
 
 function coordinates(s::Circle, nvertices=64)
     r = radius(s); o = origin(s)
-    ps = [r * Point(cos(phi), sin(phi)) + o for phi in LinRange(0, 2pi, nvertices)]
+    ps = [r * Point(cospi(phi), sinpi(phi)) + o for phi in LinRange(0, 2, nvertices)]
     # ps[end] = o
     return ps
 end
@@ -59,9 +59,9 @@ end
 
 
 function coordinates(s::Sphere, nvertices=24)
-    θ = LinRange(0, pi, nvertices)
-    φ = LinRange(0, 2pi, nvertices)
-    inner(θ, φ) = Point(cos(φ) * sin(θ), sin(φ) * sin(θ), cos(θ)) .* s.r .+ s.center
+    θ = LinRange(0, 1, nvertices)
+    φ = LinRange(0, 2, nvertices)
+    inner(θ, φ) = Point(cospi(φ) * sinpi(θ), sinpi(φ) * sinpi(θ), cospi(θ)) .* s.r .+ s.center
     return [inner(θ, φ) for φ in φ for θ in θ]
 end
 

--- a/test/geometrytypes.jl
+++ b/test/geometrytypes.jl
@@ -506,6 +506,24 @@ end
     @test Point2f(-0.5) in circle
     @test centered(Circle) == Circle(Point2f(0), 0.5f0)
     @test centered(Circle{Float64}) == Circle(Point2(0.0), 0.5)
+
+    @testset "bit-exact seam and pole vertices" begin
+        for T in (Float32, Float64)
+            n = 24
+            sphere_points = coordinates(Sphere(Point{3,T}(0.2, -0.3, 0.4), T(1.3)), n)
+            first_meridian = sphere_points[1:n]
+            last_meridian = sphere_points[(end - n + 1):end]
+            @test all(map(===, first_meridian, last_meridian))
+
+            top_pole = sphere_points[1:n:end]
+            bottom_pole = sphere_points[n:n:end]
+            @test all(p === top_pole[1] for p in top_pole)
+            @test all(p === bottom_pole[1] for p in bottom_pole)
+
+            circle_points = coordinates(Circle(Point{2,T}(0.2, -0.3), T(1.3)), n)
+            @test circle_points[1] === circle_points[end]
+        end
+    end
 end
 
 @testset "LineStrings" begin


### PR DESCRIPTION
Sphere and Circle tessellations duplicate the wrap-seam vertices on purpose (so texture coordinates can differ across the seam), but with the `cos`/`sin` over `LinRange(0, 2pi, n)` parametrization the two seam columns evaluate at 0 and 2pi and end up differing by float rounding (`cos(2pi) == 0.99999994f0` in Float32). Renderers that classify mesh edges by exact position matching, like the edge stroking in MakieOrg/Makie.jl#5727, then see the seam as a mesh boundary and stroke it at full width instead of half.

This switches the parametrization to `cospi`/`sinpi` over `LinRange(0, 2, n)`, which evaluates the wrap exactly (`cospi(2.0) === 1.0`, `sinpi(2.0) === 0.0`), so the seam columns are bit-identical while staying separate vertices. It also makes the sphere's pole rows bit-identical (previously the bottom pole vertices scattered by `cos(phi) * sin(pi) ≈ 1.2e-16`) and slightly improves the accuracy of all other vertices. Cylinder and Cone already reuse their seam vertices via `mod1` indexing and are unaffected.
