### PR TITLE
fix: avoid type var in Mesh constructor to enable JuliaC trimming

### DIFF
--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -509,7 +509,7 @@ struct Mesh{
         Dim, T <: Real,
         FT <: AbstractFace,
         Names,
-        VAT <: Tuple{<: AbstractVector{Point{Dim, T}}, Vararg{VertexAttributeType}},
+        VAT <: Tuple{<:AbstractVector{Point{Dim, T}}, Vararg{VertexAttributeType}},
         FVT <: AbstractVector{FT}
     } <: AbstractMesh{Dim, T}
 
@@ -527,17 +527,17 @@ struct Mesh{
         }
 
         va = vertex_attributes
-        names = Names
 
         # verify type
-        if !haskey(va, :position )
+        if !haskey(va, :position)
             error("Vertex attributes must have a :position attribute.")
         end
 
         if haskey(va, :normals)
             @warn "`normals` as a vertex attribute name has been deprecated in favor of `normal` to bring it in line with mesh.position and mesh.uv"
-            names = ntuple(i -> ifelse(names[i] == :normal, :normal, names[i]), length(names))
+            names = ntuple(i -> ifelse(Names[i] == :normals, :normal, Names[i]), length(Names))
             va = NamedTuple{names}(values(va))
+            return new{Dim, T, FT, names, VAT, FVT}(va, fs, views)
         end
 
         # verify that all vertex attributes refer to the same number of vertices
@@ -556,7 +556,7 @@ struct Mesh{
             end
         end
 
-        return new{Dim, T, FT, names, VAT, FVT}(va, fs, views)
+        return new{Dim, T, FT, Names, VAT, FVT}(va, fs, views)
     end
 end
 


### PR DESCRIPTION
The type variable in the `Mesh` constructor was preventing JuliaC from being able to statically resolve types for trimming. Only use a type variable when the deprecated `normals` attribute is provided. Also fix the attribute name substitution! The previous logic had a bug in it that resulted in the code not actually substituting `normals` for `normal`.